### PR TITLE
fix: preselect Default size in demo app

### DIFF
--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -59,7 +59,7 @@ function CodeField({ code, prefix }: { code: string; prefix?: string }) {
 }
 
 function App() {
-  const [selected, setSelected] = useState(0);
+  const [selected, setSelected] = useState(2);
   const [pm, setPm] = useState(0);
 
   return (


### PR DESCRIPTION
Changes the initial selected size in the demo app from XS (index 0)
to Default (index 2) so visitors see the default shadow on first load.