### PR TITLE
Align Copy/Copied text to right side of button

### DIFF
--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -48,7 +48,7 @@ function CodeField({ code, prefix }: { code: string; prefix?: string }) {
             animate={{ opacity: 1, filter: "blur(0px)", scale: 1 }}
             exit={{ opacity: 0, filter: "blur(2px)", scale: 0.9 }}
             transition={{ duration: 0.12 }}
-            className="block origin-right"
+            className="block text-right origin-right"
           >
             {copied ? "Copied" : "Copy"}
           </motion.span>


### PR DESCRIPTION
Add text-right to the animated span so both "Copy" and "Copied" labels
are consistently right-aligned, keeping the right padding uniform.

https://claude.ai/code/session_01LAP9Va6D1iLWPTADfsC9uR