### PR TITLE
Demo: theme toggle, snippet colors, and ring/shadow color switches

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "shadow-plugin",
       "devDependencies": {
-        "@tailwindcss/cli": "^4.1.13",
-        "tailwindcss": "^4.1.13",
+        "@tailwindcss/cli": "^4.3.3",
+        "tailwindcss": "^4.3.3",
       },
     },
   },
@@ -48,41 +49,41 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
 
-    "@tailwindcss/cli": ["@tailwindcss/cli@4.1.18", "", { "dependencies": { "@parcel/watcher": "^2.5.1", "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "enhanced-resolve": "^5.18.3", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.1.18" }, "bin": { "tailwindcss": "dist/index.mjs" } }, "sha512-sMZ+lZbDyxwjD2E0L7oRUjJ01Ffjtme5OtjvvnC+cV4CEDcbqzbp25TCpxHj6kWLU9+DlqJOiNgSOgctC2aZmg=="],
+    "@tailwindcss/cli": ["@tailwindcss/cli@4.3.3", "", { "dependencies": { "@parcel/watcher": "2.5.1", "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "enhanced-resolve": "^5.24.1", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.3" }, "bin": { "tailwindcss": "./dist/index.mjs" } }, "sha512-ZvS/n1ZHOBKcVlhkt8l5NNr1EDXk1NboYO5CYDOs6NUmvT9z6bzkwsosaJftY57T/3gWNzWMJzIXLodZC8ssdw=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.18", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.18", "@tailwindcss/oxide-darwin-arm64": "4.1.18", "@tailwindcss/oxide-darwin-x64": "4.1.18", "@tailwindcss/oxide-freebsd-x64": "4.1.18", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18", "@tailwindcss/oxide-linux-arm64-musl": "4.1.18", "@tailwindcss/oxide-linux-x64-gnu": "4.1.18", "@tailwindcss/oxide-linux-x64-musl": "4.1.18", "@tailwindcss/oxide-wasm32-wasi": "4.1.18", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18", "@tailwindcss/oxide-win32-x64-msvc": "4.1.18" } }, "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.1.18", "", { "os": "android", "cpu": "arm64" }, "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.1.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.1.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.1.18", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18", "", { "os": "linux", "cpu": "arm" }, "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.1.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.1.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.1.18", "", { "os": "linux", "cpu": "x64" }, "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.1.18", "", { "os": "linux", "cpu": "x64" }, "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.1.18", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.0", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.4.0" }, "cpu": "none" }, "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.1.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.18", "", { "os": "win32", "cpu": "x64" }, "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
+    "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -94,31 +95,31 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.30.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.30.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.30.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.30.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.30.2", "", { "os": "linux", "cpu": "arm" }, "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.30.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -134,21 +135,21 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
-    "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.0", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA=="],
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/demo/bun.lock
+++ b/demo/bun.lock
@@ -1,19 +1,21 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "dither-plugin-demo",
       "dependencies": {
-        "@tailwindcss/postcss": "^4.1.13",
-        "@tailwindcss/vite": "^4.1.13",
+        "@central-icons-react/round-outlined-radius-1-stroke-2": "^1.1.184",
+        "@tailwindcss/postcss": "^4.3.3",
+        "@tailwindcss/vite": "^4.3.3",
         "@vercel/analytics": "^1.5.0",
         "clsx": "^2.1.1",
         "html2canvas": "^1.4.1",
-        "lucide-react": "^0.507.0",
+        "motion": "^12.38.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss": "^4.1.13",
+        "tailwindcss": "^4.3.3",
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -71,6 +73,8 @@
     "@babel/traverse": ["@babel/traverse@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/types": "^7.28.4", "debug": "^4.3.1" } }, "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ=="],
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
+
+    "@central-icons-react/round-outlined-radius-1-stroke-2": ["@central-icons-react/round-outlined-radius-1-stroke-2@1.1.295", "", { "peerDependencies": { "react": ">=14.0.0 <= 19" } }, "sha512-nMBh8vliIMtrwLDhjbyd/i6cBE5j0QaXJbvc61z//qB+yVOKy5QI0Qv8YnNKjopfIcledqsjE/wdNqvmTwESOw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.9", "", { "os": "aix", "cpu": "ppc64" }, "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA=="],
 
@@ -150,8 +154,6 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
-
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -212,37 +214,37 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.50.2", "", { "os": "win32", "cpu": "x64" }, "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.1.13", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.5.1", "lightningcss": "1.30.1", "magic-string": "^0.30.18", "source-map-js": "^1.2.1", "tailwindcss": "4.1.13" } }, "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.13", "", { "dependencies": { "detect-libc": "^2.0.4", "tar": "^7.4.3" }, "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.13", "@tailwindcss/oxide-darwin-arm64": "4.1.13", "@tailwindcss/oxide-darwin-x64": "4.1.13", "@tailwindcss/oxide-freebsd-x64": "4.1.13", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.13", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.13", "@tailwindcss/oxide-linux-arm64-musl": "4.1.13", "@tailwindcss/oxide-linux-x64-gnu": "4.1.13", "@tailwindcss/oxide-linux-x64-musl": "4.1.13", "@tailwindcss/oxide-wasm32-wasi": "4.1.13", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.13", "@tailwindcss/oxide-win32-x64-msvc": "4.1.13" } }, "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.1.13", "", { "os": "android", "cpu": "arm64" }, "sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.1.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.1.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.1.13", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.1.13", "", { "os": "linux", "cpu": "arm" }, "sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.1.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.1.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.1.13", "", { "os": "linux", "cpu": "x64" }, "sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.1.13", "", { "os": "linux", "cpu": "x64" }, "sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.1.13", "", { "dependencies": { "@emnapi/core": "^1.4.5", "@emnapi/runtime": "^1.4.5", "@emnapi/wasi-threads": "^1.0.4", "@napi-rs/wasm-runtime": "^0.2.12", "@tybys/wasm-util": "^0.10.0", "tslib": "^2.8.0" }, "cpu": "none" }, "sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.1.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.13", "", { "os": "win32", "cpu": "x64" }, "sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
 
-    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.13", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.13", "@tailwindcss/oxide": "4.1.13", "postcss": "^8.4.41", "tailwindcss": "4.1.13" } }, "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ=="],
+    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.3", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "postcss": "^8.5.16", "tailwindcss": "4.3.3" } }, "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg=="],
 
-    "@tailwindcss/vite": ["@tailwindcss/vite@4.1.13", "", { "dependencies": { "@tailwindcss/node": "4.1.13", "@tailwindcss/oxide": "4.1.13", "tailwindcss": "4.1.13" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-0PmqLQ010N58SbMTJ7BVJ4I2xopiQn/5i6nlb4JmxzQf8zcS5+m2Cv6tqh+sfDwtIdjoEnOvwsGQ1hkUi8QEHQ=="],
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -314,8 +316,6 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
-
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -340,7 +340,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.218", "", {}, "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
+    "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
     "esbuild": ["esbuild@0.25.9", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.9", "@esbuild/android-arm": "0.25.9", "@esbuild/android-arm64": "0.25.9", "@esbuild/android-x64": "0.25.9", "@esbuild/darwin-arm64": "0.25.9", "@esbuild/darwin-x64": "0.25.9", "@esbuild/freebsd-arm64": "0.25.9", "@esbuild/freebsd-x64": "0.25.9", "@esbuild/linux-arm": "0.25.9", "@esbuild/linux-arm64": "0.25.9", "@esbuild/linux-ia32": "0.25.9", "@esbuild/linux-loong64": "0.25.9", "@esbuild/linux-mips64el": "0.25.9", "@esbuild/linux-ppc64": "0.25.9", "@esbuild/linux-riscv64": "0.25.9", "@esbuild/linux-s390x": "0.25.9", "@esbuild/linux-x64": "0.25.9", "@esbuild/netbsd-arm64": "0.25.9", "@esbuild/netbsd-x64": "0.25.9", "@esbuild/openbsd-arm64": "0.25.9", "@esbuild/openbsd-x64": "0.25.9", "@esbuild/openharmony-arm64": "0.25.9", "@esbuild/sunos-x64": "0.25.9", "@esbuild/win32-arm64": "0.25.9", "@esbuild/win32-ia32": "0.25.9", "@esbuild/win32-x64": "0.25.9" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g=="],
 
@@ -389,6 +389,8 @@
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -442,6 +444,8 @@
 
     "lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
 
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
     "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.30.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ=="],
 
     "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.30.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA=="],
@@ -468,9 +472,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.507.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XfgE6gvAHwAtnbUvWiTTHx4S3VGR+cUJHEc0vrh9Ogu672I1Tue2+Cp/8JJqpytgcBHAB1FVI297W4XGNwc2dQ=="],
-
-    "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -478,11 +480,11 @@
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+    "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
 
-    "minizlib": ["minizlib@3.0.2", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA=="],
+    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
 
-    "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
+    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -546,11 +548,9 @@
 
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
-    "tailwindcss": ["tailwindcss@4.1.13", "", {}, "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w=="],
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
-    "tapable": ["tapable@2.2.3", "", {}, "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg=="],
-
-    "tar": ["tar@7.4.3", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.0.1", "mkdirp": "^3.0.1", "yallist": "^5.0.0" } }, "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw=="],
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
@@ -559,6 +559,8 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -578,7 +580,7 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -586,17 +588,23 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
+    "@tailwindcss/node/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.5.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ=="],
+    "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" }, "bundled": true }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/postcss/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -606,9 +614,29 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,18 +2,24 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link
-      rel="icon"
-      type="image/svg+xml"
-      href="/favicon-light.svg"
-      media="(prefers-color-scheme: light)"
-    />
-    <link
-      rel="icon"
-      type="image/svg+xml"
-      href="/favicon-dark.svg"
-      media="(prefers-color-scheme: dark)"
-    />
+    <link rel="icon" type="image/svg+xml" href="/favicon-light.svg" />
+    <script>
+      // Paint the stored theme before the first frame, so a dark-mode reload
+      // never flashes white. Kept in sync with src/utils/theme.ts.
+      (function () {
+        try {
+          var stored = localStorage.getItem("theme");
+          var dark =
+            stored === "dark" ||
+            (stored !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+          document.documentElement.classList.toggle("dark", dark);
+          document.documentElement.style.colorScheme = dark ? "dark" : "light";
+          document.querySelector("link[rel='icon']").href = dark
+            ? "/favicon-dark.svg"
+            : "/favicon-light.svg";
+        } catch (e) {}
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://cdn.floriankiem.com" crossorigin />
     <title>Smooth Shadow Plugin for Tailwind CSS</title>

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,9 +14,10 @@
             (stored !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
           document.documentElement.classList.toggle("dark", dark);
           document.documentElement.style.colorScheme = dark ? "dark" : "light";
-          document.querySelector("link[rel='icon']").href = dark
-            ? "/favicon-dark.svg"
-            : "/favicon-light.svg";
+          var favicon = document.querySelector("link[rel='icon']");
+          if (favicon) favicon.href = dark ? "/favicon-dark.svg" : "/favicon-light.svg";
+          var themeColor = document.querySelector("meta[name='theme-color']");
+          if (themeColor) themeColor.content = dark ? "#000000" : "#ffffff";
         } catch (e) {}
       })();
     </script>

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,17 +11,16 @@
   },
   "dependencies": {
     "@central-icons-react/round-outlined-radius-1-stroke-2": "^1.1.184",
-    "@tailwindcss/postcss": "^4.1.13",
-    "@tailwindcss/vite": "^4.1.13",
+    "@tailwindcss/postcss": "^4.3.3",
+    "@tailwindcss/vite": "^4.3.3",
     "@vercel/analytics": "^1.5.0",
     "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
-    "lucide-react": "^0.507.0",
     "motion": "^12.38.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.13"
+    "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -67,7 +67,7 @@ function App() {
         </div>
 
         {/* Usage */}
-        <div className="w-full space-y-3">
+        <div className="w-full space-y-6">
           <h2 className="font-medium leading-tight">Usage</h2>
           <div>
             <h3 className="text-sm mb-1.5 leading-tight text-neutral-400">Tailwind stylesheet</h3>
@@ -152,7 +152,7 @@ function App() {
           <a
             href="https://x.com/nilseller"
             target="_blank"
-            className="text-neutral-500 hover:text-neutral-900 dark:hover:text-white transition-colors"
+            className="text-neutral-500 dark:text-neutral-200 hover:text-neutral-900 dark:hover:text-white transition-colors"
           >
             Nils Eller
           </a>
@@ -160,7 +160,7 @@ function App() {
           <a
             href="https://x.com/eduardwieandt"
             target="_blank"
-            className="text-neutral-500 hover:text-neutral-900 dark:hover:text-white transition-colors"
+            className="text-neutral-500 dark:text-neutral-200 hover:text-neutral-900 dark:hover:text-white transition-colors"
           >
             Eduard Wieandt
           </a>
@@ -168,9 +168,18 @@ function App() {
           <a
             href="https://x.com/flornkm"
             target="_blank"
-            className="text-neutral-500 hover:text-neutral-900 dark:hover:text-white transition-colors"
+            className="text-neutral-500 dark:text-neutral-200 hover:text-neutral-900 dark:hover:text-white transition-colors"
           >
             Florian Kiem
+          </a>
+          , in collaboration with{" "}
+          <a
+            href="https://rogo.ai/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-neutral-500 dark:text-neutral-200 hover:text-neutral-900 dark:hover:text-white transition-colors"
+          >
+            Rogo
           </a>
         </p>
       </div>

--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -1,6 +1,9 @@
-import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
+import { CodeField, CopyBlock } from "./components/code-field";
+import { ShadowPlayground } from "./components/shadow-playground";
+import { ThemeToggle } from "./components/theme-toggle";
 import { cn } from "./utils/cn";
+import { useTheme } from "./utils/theme";
 import skillContent from "../../.claude/skills/smooth-shadow-ring/SKILL.md?raw";
 import bugbotContent from "../../BUGBOT.md?raw";
 
@@ -14,58 +17,6 @@ function GitHubIcon({ className }: { className?: string }) {
   );
 }
 
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const copy = () => {
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
-
-  return (
-    <button
-      onClick={copy}
-      className="relative text-sm cursor-pointer text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 font-medium h-5 w-12 shrink-0"
-    >
-      <AnimatePresence mode="wait" initial={false}>
-        <motion.span
-          key={copied ? "copied" : "copy"}
-          initial={{ opacity: 0, filter: "blur(2px)", scale: 0.9 }}
-          animate={{ opacity: 1, filter: "blur(0px)", scale: 1 }}
-          exit={{ opacity: 0, filter: "blur(2px)", scale: 0.9 }}
-          transition={{ duration: 0.12 }}
-          className="block text-right origin-right"
-        >
-          {copied ? "Copied" : "Copy"}
-        </motion.span>
-      </AnimatePresence>
-    </button>
-  );
-}
-
-function CopyBlock({ filename, content }: { filename: string; content: string }) {
-  return (
-    <div className="w-full rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden">
-      <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-b border-neutral-200 dark:border-neutral-800">
-        <span className="min-w-0 truncate font-mono text-xs text-neutral-400">{filename}</span>
-        <CopyButton text={content} />
-      </div>
-      <pre className="tabular-nums font-mono text-xs leading-relaxed text-neutral-600 dark:text-neutral-300 p-4 max-h-80 overflow-auto whitespace-pre scrollbar-none">
-        {content.trim()}
-      </pre>
-    </div>
-  );
-}
-
-const SIZES = [
-  { label: "XS", smooth: "smooth-shadow-xs", ring: "smooth-shadow-ring-xs", tailwind: "shadow-xs" },
-  { label: "SM", smooth: "smooth-shadow-sm", ring: "smooth-shadow-ring-sm", tailwind: "shadow-sm" },
-  { label: "Default", smooth: "smooth-shadow", ring: "smooth-shadow-ring", tailwind: "shadow" },
-  { label: "LG", smooth: "smooth-shadow-lg", ring: "smooth-shadow-ring-lg", tailwind: "shadow-lg" },
-  { label: "XL", smooth: "smooth-shadow-xl", ring: "smooth-shadow-ring-xl", tailwind: "shadow-xl" },
-];
-
 const INSTALL_COMMANDS = [
   { label: "npm", command: "npm i shadow-plugin" },
   { label: "pnpm", command: "pnpm add shadow-plugin" },
@@ -73,147 +24,25 @@ const INSTALL_COMMANDS = [
   { label: "bun", command: "bun add shadow-plugin" },
 ];
 
-function CodeField({ code, prefix }: { code: string; prefix?: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
-
-  return (
-    <div className="flex items-start justify-between gap-3 w-full rounded-xl border border-neutral-200 dark:border-neutral-800 px-4 py-3 overflow-hidden">
-      <div className="min-w-0 flex-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
-        <pre className="tabular-nums font-normal text-sm whitespace-pre overflow-x-auto scrollbar-none">
-          {prefix && <span className="text-neutral-300 dark:text-neutral-600 mr-2">{prefix}</span>}
-          {code}
-        </pre>
-      </div>
-      <button
-        onClick={copy}
-        className="relative text-sm cursor-pointer text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 font-medium h-5 w-12 shrink-0"
-      >
-        <AnimatePresence mode="wait" initial={false}>
-          <motion.span
-            key={copied ? "copied" : "copy"}
-            initial={{ opacity: 0, filter: "blur(2px)", scale: 0.9 }}
-            animate={{ opacity: 1, filter: "blur(0px)", scale: 1 }}
-            exit={{ opacity: 0, filter: "blur(2px)", scale: 0.9 }}
-            transition={{ duration: 0.12 }}
-            className="block text-right origin-right"
-          >
-            {copied ? "Copied" : "Copy"}
-          </motion.span>
-        </AnimatePresence>
-      </button>
-    </div>
-  );
-}
-
 function App() {
-  const [selected, setSelected] = useState(2);
-  const [ring, setRing] = useState(true);
+  const { theme, resolved, setTheme } = useTheme();
   const [pm, setPm] = useState(0);
 
   return (
     <main className="min-h-screen px-4 pt-4 pb-8 md:py-20">
       <div className="w-full max-w-3xl flex space-y-12 flex-col items-start mx-auto">
-        <div className="space-y-2">
-          <h1 className="text-base font-medium leading-tight">Smooth Shadow Plugin</h1>
-          <p className="text-sm mb-1.5 leading-tight text-neutral-400">
-            A simple tailwind plugin that makes your shadows finally look good.
-          </p>
+        <div className="w-full flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="text-base font-medium leading-tight">Smooth Shadow Plugin</h1>
+            <p className="text-sm mb-1.5 leading-tight text-neutral-400">
+              A simple tailwind plugin that makes your shadows finally look good.
+            </p>
+          </div>
+          <ThemeToggle theme={theme} onChange={setTheme} />
         </div>
 
         {/* Example */}
-        <div className="w-full space-y-5">
-          <h2 className="font-medium leading-tight">Try it out</h2>
-          <div className="p-8 rounded-md bg-neutral-50 dark:bg-neutral-900 space-y-6">
-            <div className="flex items-center justify-center gap-8 sm:gap-16 px-4 sm:px-8 py-16 sm:py-24">
-              <div className="flex flex-col items-center gap-3">
-                <div
-                  className={cn(
-                    "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl shadow-black/10 dark:shadow-white/10 transition-shadow duration-300",
-                    SIZES[selected].tailwind
-                  )}
-                />
-                <span className="text-sm text-neutral-400">Default</span>
-              </div>
-              <div className="flex flex-col items-center gap-3">
-                <div
-                  className={cn(
-                    "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-300",
-                    ring ? SIZES[selected].ring : SIZES[selected].smooth
-                  )}
-                />
-                <span className="text-sm text-neutral-400">
-                  {ring ? "Smooth + ring" : "Smooth"}
-                </span>
-              </div>
-            </div>
-            <div className="flex flex-wrap items-center justify-center gap-x-1 gap-y-2">
-              <div className="flex items-center gap-1">
-                {SIZES.map((size, i) => (
-                  <button
-                    key={size.label}
-                    onClick={() => setSelected(i)}
-                    className={cn(
-                      "relative px-3 py-1 cursor-pointer rounded-full text-xs font-medium whitespace-nowrap transition-colors",
-                      selected === i
-                        ? "text-neutral-900 dark:text-white"
-                        : "text-neutral-400 hover:text-neutral-500"
-                    )}
-                  >
-                    {selected === i && (
-                      <motion.span
-                        layoutId="size-selector"
-                        className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-full"
-                        transition={{
-                          type: "spring",
-                          duration: 0.4,
-                          bounce: 0.15,
-                        }}
-                      />
-                    )}
-                    <span className="relative z-10">{size.label}</span>
-                  </button>
-                ))}
-              </div>
-              <span className="hidden sm:block w-px h-4 mx-1.5 bg-neutral-200 dark:bg-neutral-700" />
-              <div className="flex items-center gap-1">
-                {[
-                  { label: "Ring", value: true },
-                  { label: "No ring", value: false },
-                ].map((option) => (
-                  <button
-                    key={option.label}
-                    onClick={() => setRing(option.value)}
-                    className={cn(
-                      "relative px-3 py-1 cursor-pointer rounded-full text-xs font-medium whitespace-nowrap transition-colors",
-                      ring === option.value
-                        ? "text-neutral-900 dark:text-white"
-                        : "text-neutral-400 hover:text-neutral-500"
-                    )}
-                  >
-                    {ring === option.value && (
-                      <motion.span
-                        layoutId="ring-selector"
-                        className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-full"
-                        transition={{
-                          type: "spring",
-                          duration: 0.4,
-                          bounce: 0.15,
-                        }}
-                      />
-                    )}
-                    <span className="relative z-10">{option.label}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
+        <ShadowPlayground theme={resolved} />
 
         {/* Install */}
         <div className="w-full space-y-3">
@@ -234,7 +63,7 @@ function App() {
               </button>
             ))}
           </div>
-          <CodeField code={INSTALL_COMMANDS[pm].command} prefix="$" />
+          <CodeField code={INSTALL_COMMANDS[pm].command} prefix="$" language="shell" />
         </div>
 
         {/* Usage */}
@@ -242,23 +71,26 @@ function App() {
           <h2 className="font-medium leading-tight">Usage</h2>
           <div>
             <h3 className="text-sm mb-1.5 leading-tight text-neutral-400">Tailwind stylesheet</h3>
-            <CodeField code="@import 'shadow-plugin';" />
+            <CodeField code="@import 'shadow-plugin';" language="css" />
           </div>
           <div>
             <h3 className="text-sm mb-1.5 leading-tight text-neutral-400">Element classes</h3>
-            <CodeField code="<div className='smooth-shadow-md' />" />
+            <CodeField code="<div className='smooth-shadow-md' />" language="html" />
           </div>
           <div>
             <h3 className="text-sm mb-1.5 leading-tight text-neutral-400">
               Shadow + ring for elevated surfaces
             </h3>
-            <CodeField code="<div className='smooth-shadow-ring-md' />" />
+            <CodeField code="<div className='smooth-shadow-ring-md' />" language="html" />
           </div>
           <div>
             <h3 className="text-sm mb-1.5 leading-tight text-neutral-400">
               Adjust ring and shadow color independently
             </h3>
-            <CodeField code="<div className='smooth-shadow-ring-md smooth-ring-blue-500/40 shadow-red-500' />" />
+            <CodeField
+              code="<div className='smooth-shadow-ring-md smooth-ring-blue-500/40 shadow-red-500' />"
+              language="html"
+            />
           </div>
           <div>
             <h3 className="text-sm mb-1.5 leading-tight text-neutral-400">
@@ -266,6 +98,7 @@ function App() {
             </h3>
             <CodeField
               code={`@theme {\n  --shadow-xs: var(--smooth-shadow-xs);\n  --shadow-sm: var(--smooth-shadow-sm);\n  --shadow-md: var(--smooth-shadow-md);\n  --shadow-lg: var(--smooth-shadow-lg);\n  --shadow-xl: var(--smooth-shadow-xl);\n  --shadow-2xl: var(--smooth-shadow-2xl);\n}`}
+              language="css"
             />
           </div>
         </div>
@@ -279,18 +112,28 @@ function App() {
             <h2 className="font-medium leading-tight">Agent skills</h2>
             <p className="text-sm leading-tight text-neutral-400">
               Drop these into your AI tools so they stop pairing a{" "}
-              <code className="font-mono text-neutral-500 dark:text-neutral-400">border</code> with a{" "}
-              <code className="font-mono text-neutral-500 dark:text-neutral-400">shadow</code> (the double edge) and
-              reach for <code className="font-mono text-neutral-500 dark:text-neutral-400">smooth-shadow-ring</code>{" "}
+              <code className="font-mono text-neutral-500 dark:text-neutral-400">border</code> with
+              a <code className="font-mono text-neutral-500 dark:text-neutral-400">shadow</code>{" "}
+              (the double edge) and reach for{" "}
+              <code className="font-mono text-neutral-500 dark:text-neutral-400">
+                smooth-shadow-ring
+              </code>{" "}
               instead.
             </p>
           </div>
           <div>
-            <h3 className="text-sm mb-1.5 leading-tight text-neutral-900 dark:text-white">Claude / agent skill</h3>
-            <CopyBlock filename=".claude/skills/smooth-shadow-ring/SKILL.md" content={skillContent} />
+            <h3 className="text-sm mb-1.5 leading-tight text-neutral-900 dark:text-white">
+              Claude / agent skill
+            </h3>
+            <CopyBlock
+              filename=".claude/skills/smooth-shadow-ring/SKILL.md"
+              content={skillContent}
+            />
           </div>
           <div>
-            <h3 className="text-sm mb-1.5 leading-tight text-neutral-900 dark:text-white">Cursor Bugbot rule</h3>
+            <h3 className="text-sm mb-1.5 leading-tight text-neutral-900 dark:text-white">
+              Cursor Bugbot rule
+            </h3>
             <CopyBlock filename="BUGBOT.md" content={bugbotContent} />
           </div>
           <a

--- a/demo/src/components/code-field.tsx
+++ b/demo/src/components/code-field.tsx
@@ -1,0 +1,64 @@
+import { CopyButton } from "./copy-button";
+import { cn } from "../utils/cn";
+import { detectLanguage, highlight, type Language } from "../utils/highlight";
+
+/** Single-line snippet: the code, softly colored, with a copy button on the right. */
+export function CodeField({
+  code,
+  prefix,
+  language,
+  wrap = false,
+}: {
+  code: string;
+  prefix?: string;
+  language?: Language;
+  /** Let long snippets break onto a second line instead of scrolling under the fade. */
+  wrap?: boolean;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3 w-full rounded-xl border border-neutral-200 dark:border-neutral-800 px-4 py-3 overflow-hidden">
+      <div
+        className={cn(
+          "min-w-0 flex-1",
+          !wrap && "[mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]"
+        )}
+      >
+        <pre
+          className={cn(
+            "tabular-nums font-normal text-sm text-neutral-600 dark:text-neutral-300",
+            wrap
+              ? "whitespace-pre-wrap break-words"
+              : "whitespace-pre overflow-x-auto scrollbar-none"
+          )}
+        >
+          {prefix && <span className="text-neutral-300 dark:text-neutral-600 mr-2">{prefix}</span>}
+          {highlight(code, language ?? detectLanguage(code))}
+        </pre>
+      </div>
+      <CopyButton text={code} />
+    </div>
+  );
+}
+
+/** Multi-line snippet with a filename header — used for the agent skill files. */
+export function CopyBlock({
+  filename,
+  content,
+  language = "markdown",
+}: {
+  filename: string;
+  content: string;
+  language?: Language;
+}) {
+  return (
+    <div className="w-full rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden">
+      <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-b border-neutral-200 dark:border-neutral-800">
+        <span className="min-w-0 truncate font-mono text-xs text-neutral-400">{filename}</span>
+        <CopyButton text={content} />
+      </div>
+      <pre className="tabular-nums font-mono text-xs leading-relaxed text-neutral-600 dark:text-neutral-300 p-4 max-h-80 overflow-auto whitespace-pre scrollbar-none">
+        {highlight(content.trim(), language)}
+      </pre>
+    </div>
+  );
+}

--- a/demo/src/components/code-field.tsx
+++ b/demo/src/components/code-field.tsx
@@ -9,6 +9,7 @@ export function CodeField({
   language,
   wrap = false,
   plain = false,
+  bare = false,
 }: {
   code: string;
   prefix?: string;
@@ -18,9 +19,17 @@ export function CodeField({
   /** Drop the syntax colors. For snippets that live next to a color picker,
       where a second palette in the code is one palette too many. */
   plain?: boolean;
+  /** Drop the box. For a snippet that's already a section of a bordered panel,
+      where its own edge would just double the one around it. */
+  bare?: boolean;
 }) {
   return (
-    <div className="flex items-start justify-between gap-3 w-full rounded-xl border border-neutral-200 dark:border-neutral-800 px-4 py-3 overflow-hidden">
+    <div
+      className={cn(
+        "flex items-start justify-between gap-3 w-full px-4 py-3 overflow-hidden",
+        !bare && "rounded-xl border border-neutral-200 dark:border-neutral-800"
+      )}
+    >
       <div
         className={cn(
           "min-w-0 flex-1",

--- a/demo/src/components/code-field.tsx
+++ b/demo/src/components/code-field.tsx
@@ -1,3 +1,4 @@
+import { motion } from "motion/react";
 import { CopyButton } from "./copy-button";
 import { cn } from "../utils/cn";
 import { detectLanguage, highlight, type Language } from "../utils/highlight";
@@ -37,7 +38,17 @@ export function CodeField({
           )}
         >
           {prefix && <span className="text-neutral-300 dark:text-neutral-600 mr-2">{prefix}</span>}
-          {plain ? code : highlight(code, language ?? detectLanguage(code))}
+          {/* Keyed on the code, so a snippet driven by controls fades between
+              values instead of snapping. Static snippets never rekey, so this
+              costs them nothing. */}
+          <motion.span
+            key={code}
+            initial={{ opacity: 0, filter: "blur(2px)" }}
+            animate={{ opacity: 1, filter: "blur(0px)" }}
+            transition={{ duration: 0.18, ease: "easeOut" }}
+          >
+            {plain ? code : highlight(code, language ?? detectLanguage(code))}
+          </motion.span>
         </pre>
       </div>
       <CopyButton text={code} />

--- a/demo/src/components/code-field.tsx
+++ b/demo/src/components/code-field.tsx
@@ -8,12 +8,16 @@ export function CodeField({
   prefix,
   language,
   wrap = false,
+  plain = false,
 }: {
   code: string;
   prefix?: string;
   language?: Language;
   /** Let long snippets break onto a second line instead of scrolling under the fade. */
   wrap?: boolean;
+  /** Drop the syntax colors. For snippets that live next to a color picker,
+      where a second palette in the code is one palette too many. */
+  plain?: boolean;
 }) {
   return (
     <div className="flex items-start justify-between gap-3 w-full rounded-xl border border-neutral-200 dark:border-neutral-800 px-4 py-3 overflow-hidden">
@@ -25,14 +29,15 @@ export function CodeField({
       >
         <pre
           className={cn(
-            "tabular-nums font-normal text-sm text-neutral-600 dark:text-neutral-300",
+            "tabular-nums font-normal text-sm",
+            plain ? "text-neutral-900 dark:text-white" : "text-neutral-600 dark:text-neutral-300",
             wrap
               ? "whitespace-pre-wrap break-words"
               : "whitespace-pre overflow-x-auto scrollbar-none"
           )}
         >
           {prefix && <span className="text-neutral-300 dark:text-neutral-600 mr-2">{prefix}</span>}
-          {highlight(code, language ?? detectLanguage(code))}
+          {plain ? code : highlight(code, language ?? detectLanguage(code))}
         </pre>
       </div>
       <CopyButton text={code} />

--- a/demo/src/components/code-field.tsx
+++ b/demo/src/components/code-field.tsx
@@ -1,4 +1,3 @@
-import { motion } from "motion/react";
 import { CopyButton } from "./copy-button";
 import { cn } from "../utils/cn";
 import { detectLanguage, highlight, type Language } from "../utils/highlight";
@@ -38,17 +37,7 @@ export function CodeField({
           )}
         >
           {prefix && <span className="text-neutral-300 dark:text-neutral-600 mr-2">{prefix}</span>}
-          {/* Keyed on the code, so a snippet driven by controls fades between
-              values instead of snapping. Static snippets never rekey, so this
-              costs them nothing. */}
-          <motion.span
-            key={code}
-            initial={{ opacity: 0, filter: "blur(2px)" }}
-            animate={{ opacity: 1, filter: "blur(0px)" }}
-            transition={{ duration: 0.18, ease: "easeOut" }}
-          >
-            {plain ? code : highlight(code, language ?? detectLanguage(code))}
-          </motion.span>
+          {plain ? code : highlight(code, language ?? detectLanguage(code))}
         </pre>
       </div>
       <CopyButton text={code} />

--- a/demo/src/components/copy-button.tsx
+++ b/demo/src/components/copy-button.tsx
@@ -1,0 +1,32 @@
+import { AnimatePresence, motion } from "motion/react";
+import { useState } from "react";
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <button
+      onClick={copy}
+      className="relative text-sm cursor-pointer text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 font-medium h-5 w-12 shrink-0"
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.span
+          key={copied ? "copied" : "copy"}
+          initial={{ opacity: 0, filter: "blur(2px)", scale: 0.9 }}
+          animate={{ opacity: 1, filter: "blur(0px)", scale: 1 }}
+          exit={{ opacity: 0, filter: "blur(2px)", scale: 0.9 }}
+          transition={{ duration: 0.12 }}
+          className="block text-right origin-right"
+        >
+          {copied ? "Copied" : "Copy"}
+        </motion.span>
+      </AnimatePresence>
+    </button>
+  );
+}

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -217,7 +217,10 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
             </Segmented>
           </div>
 
-          <div className="space-y-2.5">
+          {/* Each segment carries a dot of the color it currently holds, so the
+              swatch you click visibly lands in the selected one — that is what
+              ties this control to the row underneath it. */}
+          <div className="space-y-2">
             <div className="flex justify-center">
               <Segmented>
                 {(["shadow", "ring"] as const).map((key) => (
@@ -228,7 +231,20 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
                     disabled={key === "ring" && !ring}
                     onClick={() => setTarget(key)}
                   >
-                    {key === "shadow" ? "Shadow" : "Ring"}
+                    <span className="flex items-center gap-1.5">
+                      <span
+                        className={cn(
+                          "size-2.5 rounded-full ring-1 transition-colors",
+                          key === "ring" && !ring
+                            ? "bg-transparent ring-neutral-300 dark:ring-neutral-600"
+                            : "ring-black/15 dark:ring-white/25"
+                        )}
+                        style={
+                          key === "ring" && !ring ? undefined : { backgroundColor: colors[key] }
+                        }
+                      />
+                      {key === "shadow" ? "Shadow" : "Ring"}
+                    </span>
                   </Segment>
                 ))}
               </Segmented>

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -1,5 +1,5 @@
-import { motion } from "motion/react";
-import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { CodeField } from "./code-field";
 import { cn } from "../utils/cn";
 import type { ResolvedTheme } from "../utils/theme";
@@ -7,7 +7,11 @@ import type { ResolvedTheme } from "../utils/theme";
 const SIZES = [
   { label: "XS", smooth: "smooth-shadow-xs", ring: "smooth-shadow-ring-xs", tailwind: "shadow-xs" },
   { label: "SM", smooth: "smooth-shadow-sm", ring: "smooth-shadow-ring-sm", tailwind: "shadow-sm" },
-  { label: "Default", smooth: "smooth-shadow", ring: "smooth-shadow-ring", tailwind: "shadow" },
+  /* "MD" rather than "Default": every other label is ~15px wide and that one was
+     39px, so the reserved slot it forced left a visible hole next to whichever
+     side of it was aligned. It also freed up "Default" for the left preview box,
+     which uses it to mean Tailwind's own shadow. */
+  { label: "MD", smooth: "smooth-shadow", ring: "smooth-shadow-ring", tailwind: "shadow" },
   { label: "LG", smooth: "smooth-shadow-lg", ring: "smooth-shadow-ring-lg", tailwind: "shadow-lg" },
   { label: "XL", smooth: "smooth-shadow-xl", ring: "smooth-shadow-ring-xl", tailwind: "shadow-xl" },
 ];
@@ -57,13 +61,60 @@ type Colors = Record<Target, string>;
    a white shadow on a dark ground reads as a glow around the box rather than a
    shadow under it. Only the ring flips, since a black hairline disappears
    there. Until the shadow is actually tinted we set no color at all, so both
-   previews render exactly what the page shipped with. */
+   previews render exactly what the page shipped with.
+
+   The dark ring has to be *lighter* than the preview box, not darker: the ring
+   paints outside the box, and the old `neutral-600` was dimmer than the
+   `neutral-800` box, so it left no visible edge at all. `neutral-400` clears
+   the box without going to the glare of a full white hairline. */
 const DEFAULT_SHADOW = "#000000";
 const LIGHT_DEFAULTS: Colors = { shadow: DEFAULT_SHADOW, ring: "#d4d4d4" };
-const DARK_DEFAULTS: Colors = { shadow: DEFAULT_SHADOW, ring: "#525252" };
+const DARK_DEFAULTS: Colors = { shadow: DEFAULT_SHADOW, ring: "#a3a3a3" };
 
 function mix(hex: string, alpha: number) {
   return `color-mix(in srgb, ${hex} ${alpha}%, transparent)`;
+}
+
+/* The surface the selection ring is drawn against — the control panel, not the
+   card behind it, since that's what the swatches actually sit on. */
+const PANEL: Record<ResolvedTheme, string> = { light: "#ffffff", dark: "#171717" };
+/* A 1.5px ring is decorative, not text, so this sits far below the WCAG 4.5:1
+   for copy — it's just the floor at which the hairline stops disappearing. */
+const MIN_RING_CONTRAST = 1.6;
+
+const channels = (hex: string) => [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+
+function luminance(hex: string) {
+  const [r, g, b] = channels(hex)
+    .map((c) => c / 255)
+    .map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: string, b: string) {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function blend(hex: string, toward: string, amount: number) {
+  const [a, b] = [channels(hex), channels(toward)];
+  const hexed = a.map((c, i) => Math.round(c * (1 - amount) + b[i] * amount));
+  return `#${hexed.map((c) => c.toString(16).padStart(2, "0")).join("")}`;
+}
+
+/* The selection ring wears the swatch's own color — but white on the light card
+   (or black on the dark one) is a ring you can't see. Walk the color toward the
+   opposite end of the scale until it clears the floor above; anything that
+   already contrasts is returned untouched, so saturated swatches keep their
+   exact hue and only the near-invisible ends get pulled. */
+function ringColor(hex: string, theme: ResolvedTheme) {
+  const panel = PANEL[theme];
+  const toward = theme === "dark" ? "#ffffff" : "#000000";
+  for (let amount = 0; amount < 1; amount += 0.1) {
+    const candidate = blend(hex, toward, amount);
+    if (contrast(candidate, panel) >= MIN_RING_CONTRAST) return candidate;
+  }
+  return toward;
 }
 
 function tokenFor(hex: string) {
@@ -75,7 +126,7 @@ function tokenFor(hex: string) {
    smooth-shadow-ring-xs, so the page is wearing the thing it sells. */
 function Segmented({ children }: { children: ReactNode }) {
   return (
-    <div className="flex items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-800">
+    <div className="flex w-fit items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-800">
       {children}
     </div>
   );
@@ -86,12 +137,15 @@ function Segment({
   layoutId,
   onClick,
   disabled,
+  dot,
   children,
 }: {
   active: boolean;
   layoutId: string;
   onClick: () => void;
   disabled?: boolean;
+  /** Hex to show as a swatch before the label — what this option currently is. */
+  dot?: string;
   children: ReactNode;
 }) {
   return (
@@ -99,7 +153,10 @@ function Segment({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "relative rounded-full px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-colors",
+        "relative rounded-full py-1 text-xs font-medium whitespace-nowrap transition-colors",
+        // A dot reads as its own left margin, so it needs less padding than text
+        // would to sit the same distance off the pill's edge.
+        dot ? "pr-2.5 pl-1.5" : "px-2.5",
         disabled
           ? "cursor-not-allowed text-neutral-300 dark:text-neutral-600"
           : active
@@ -114,7 +171,192 @@ function Segment({
           transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
         />
       )}
-      <span className="relative z-10">{children}</span>
+      <span className="relative z-10 flex items-center gap-1.5">
+        {dot && (
+          // The hairline keeps a white dot from vanishing into the raised thumb.
+          <span
+            className={cn(
+              "size-2.5 rounded-full border border-black/10 dark:border-white/20 transition-opacity",
+              disabled && "opacity-40"
+            )}
+            style={{ backgroundColor: dot }}
+          />
+        )}
+        {children}
+      </span>
+    </button>
+  );
+}
+
+/* One settings row: label in a fixed column on the left, control on the right.
+   The fixed column is what actually lines the panel up — every control starts
+   at the same x no matter how long its label is. */
+function Field({
+  label,
+  align = "center",
+  children,
+}: {
+  label: string;
+  /** `start` for controls taller than one line, so the label sits on the first. */
+  align?: "center" | "start";
+  children: ReactNode;
+}) {
+  return (
+    // Stacks below `sm`, where a fixed label column plus a control leaves too
+    // little width for either. The control wrapper needs `min-w-0`: a flex child
+    // defaults to `min-width: auto`, so without it the swatches refuse to shrink
+    // and punch straight out of the panel instead of wrapping.
+    <div
+      className={cn(
+        "flex flex-col gap-1 sm:flex-row sm:gap-4",
+        align === "start" ? "sm:items-start" : "sm:items-center"
+      )}
+    >
+      <span
+        className={cn(
+          "text-xs text-neutral-400 sm:w-12 sm:shrink-0",
+          // Clears the segmented control's own padding so the two texts line up.
+          align === "start" && "sm:pt-1.5"
+        )}
+      >
+        {label}
+      </span>
+      <div className="min-w-0 sm:flex-1">{children}</div>
+    </div>
+  );
+}
+
+/* Fill and thumb are motion-driven, so dragging between the five steps springs
+   rather than snapping, and the hover halo has a real element to transition on.
+   The native input rides on top at zero opacity and does the actual input
+   handling — pointer drag, arrow keys, screen readers. */
+function SizeSlider({
+  value,
+  onChange,
+  label,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+  label: string;
+}) {
+  /* Travel is measured in px, not percent: at 100% the thumb's center would sit
+     on the track's end and half of it would hang past into the label. Its centre
+     runs from one radius in to one radius short instead. */
+  const TRACK = 160; // w-40
+  const THUMB = 16; // size-4
+  const centre = THUMB / 2 + (value / (SIZES.length - 1)) * (TRACK - THUMB);
+  const spring = { type: "spring", stiffness: 400, damping: 32 } as const;
+
+  return (
+    <div className="size-slider relative h-4" style={{ width: TRACK }}>
+      <div
+        className="absolute inset-x-0 top-1/2 h-1.5 -translate-y-1/2 rounded-full transition-colors"
+        style={{ backgroundColor: "var(--slider-track)" }}
+      />
+      {/* `initial={false}` on both: motion would otherwise animate up from the
+          element's computed start, and `left: auto` has nothing to spring from. */}
+      <motion.div
+        className="absolute left-0 top-1/2 h-1.5 -translate-y-1/2 rounded-full transition-colors"
+        style={{ backgroundColor: "var(--slider-fill)" }}
+        initial={false}
+        animate={{ width: centre }}
+        transition={spring}
+      />
+      {/* `y` rather than a `-translate-y-1/2` class: motion owns the transform
+          on an element it animates, and a Tailwind translate would be dropped. */}
+      <motion.div
+        className="absolute top-1/2 left-0"
+        style={{ y: "-50%" }}
+        initial={false}
+        animate={{ left: centre }}
+        transition={spring}
+      >
+        <div className="size-slider-thumb size-4 -translate-x-1/2 rounded-full" />
+      </motion.div>
+      <input
+        type="range"
+        min={0}
+        max={SIZES.length - 1}
+        step={1}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        aria-label="Shadow size"
+        aria-valuetext={label}
+        className="size-slider-input absolute inset-0 m-0 h-full w-full opacity-0"
+      />
+    </div>
+  );
+}
+
+/* The preview box. The plugin's sizes don't share a layer count (xs stacks 2
+   shadows, sm 7, the rest 6), so CSS can't tween between them — box-shadow only
+   interpolates when both sides have the same shape, and otherwise it snaps. So
+   the shadow lives on a bare overlay above an opaque box, and motion cross-fades
+   a new overlay in over the outgoing one. Any pair of sizes blends smoothly,
+   and the box underneath never goes translucent mid-transition. */
+function Stage({
+  shadowKey,
+  className,
+  style,
+}: {
+  shadowKey: string;
+  className: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <div className="relative size-24 sm:size-32 rounded-2xl bg-white dark:bg-neutral-800">
+      <AnimatePresence initial={false}>
+        <motion.div
+          key={shadowKey}
+          // Colors still change on the same overlay, so they keep a plain CSS
+          // transition rather than re-mounting and cross-fading.
+          className={cn("absolute inset-0 rounded-2xl transition-shadow duration-300", className)}
+          style={style}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.35, ease: [0.32, 0.72, 0, 1] }}
+        />
+      </AnimatePresence>
+    </div>
+  );
+}
+
+/* The switch from florians-site (redesign-2): a 32×20 track with a 16px knob
+   that slides on `right`, 200ms ease-out, no spring. Same geometry, wired to
+   this page's neutral scale instead of that site's tokens. */
+function Switch({
+  checked,
+  onCheckedChange,
+  label,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  /** Names the switch for screen readers; the row's own label carries it visually. */
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onCheckedChange(!checked)}
+      className="inline-flex cursor-pointer items-center"
+    >
+      <span
+        className={cn(
+          "relative h-5 w-8 rounded-full p-0.5 transition-all duration-200 ease-out",
+          checked ? "bg-neutral-900 dark:bg-white" : "bg-neutral-200 dark:bg-neutral-800"
+        )}
+      >
+        <span
+          className={cn(
+            "absolute top-1/2 z-10 size-4 -translate-y-1/2 rounded-full transition-all duration-200 ease-out",
+            checked ? "right-0.5 bg-white dark:bg-black" : "right-3.5 bg-white dark:bg-neutral-600"
+          )}
+        />
+      </span>
     </button>
   );
 }
@@ -126,11 +368,17 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
   const [colors, setColors] = useState<Colors>(() =>
     theme === "dark" ? DARK_DEFAULTS : LIGHT_DEFAULTS
   );
+  const picked = useRef<Partial<Record<Target, boolean>>>({});
 
-  // A black hairline is invisible on black, so follow the theme back to
-  // sensible defaults whenever it flips.
+  // A black hairline is invisible on black, so untouched colors follow the
+  // theme back to sensible defaults whenever it flips. Anything the visitor
+  // picked themselves survives — flipping the theme shouldn't undo their work.
   useEffect(() => {
-    setColors(theme === "dark" ? DARK_DEFAULTS : LIGHT_DEFAULTS);
+    const defaults = theme === "dark" ? DARK_DEFAULTS : LIGHT_DEFAULTS;
+    setColors((prev) => ({
+      shadow: picked.current.shadow ? prev.shadow : defaults.shadow,
+      ring: picked.current.ring ? prev.ring : defaults.ring,
+    }));
   }, [theme]);
 
   // `smooth-ring-*` does nothing without a ring, so don't offer it as a target.
@@ -149,17 +397,15 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
   return (
     <div className="w-full space-y-5">
       <h2 className="font-medium leading-tight">Try it out</h2>
-      <div className="p-2 rounded-xl bg-neutral-50 dark:bg-neutral-900 space-y-6">
-        {/* The stage is its own surface, raised off the card, so the demo sits
-            on something rather than floating in the same flat box as the
-            controls. */}
-        <div className="flex items-center justify-center gap-8 sm:gap-16 rounded-lg bg-white dark:bg-neutral-950 px-4 sm:px-8 py-12 sm:py-16 smooth-shadow-ring-xs">
+      {/* Concentric radii: the card's 16px minus its 8px padding leaves exactly
+          the panel's 8px, so the two curves stay parallel instead of the inner
+          one bulging against a wider outer corner. */}
+      <div className="p-2 rounded-2xl bg-neutral-50 dark:bg-neutral-950 space-y-2">
+        <div className="flex items-center justify-center gap-8 sm:gap-16 px-6 py-24">
           <div className="flex flex-col items-center gap-3">
-            <div
-              className={cn(
-                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl shadow-black/10 dark:shadow-white/10 transition-shadow duration-300",
-                size.tailwind
-              )}
+            <Stage
+              shadowKey={size.tailwind}
+              className={cn("shadow-black/10 dark:shadow-white/10", size.tailwind)}
               style={
                 shadowTinted
                   ? ({
@@ -171,11 +417,9 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
             <span className="text-sm text-neutral-400">Default</span>
           </div>
           <div className="flex flex-col items-center gap-3">
-            <div
-              className={cn(
-                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-300",
-                ring ? size.ring : size.smooth
-              )}
+            <Stage
+              shadowKey={ring ? size.ring : size.smooth}
+              className={ring ? size.ring : size.smooth}
               style={
                 {
                   ...(shadowTinted ? { "--tw-shadow-color": colors.shadow } : {}),
@@ -187,77 +431,104 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
           </div>
         </div>
 
-        {/* Controls sit centered under the preview, in two groups: what the
-            shadow is, then what color it is. No labels — the options say it. */}
-        <div className="space-y-5 px-4 pb-4">
-          <div className="flex flex-wrap items-center justify-center gap-2">
-            <Segmented>
-              {SIZES.map((option, i) => (
-                <Segment
-                  key={option.label}
-                  active={selected === i}
-                  layoutId="size-selector"
-                  onClick={() => setSelected(i)}
-                >
-                  {option.label}
-                </Segment>
-              ))}
-            </Segmented>
-            <Segmented>
-              {[
-                { label: "Ring", value: true },
-                { label: "No ring", value: false },
-              ].map((option) => (
-                <Segment
-                  key={option.label}
-                  active={ring === option.value}
-                  layoutId="ring-selector"
-                  onClick={() => setRing(option.value)}
-                >
-                  {option.label}
-                </Segment>
-              ))}
-            </Segmented>
-          </div>
+        {/* The controls get their own raised surface inside the card, wearing
+            the plugin's own elevated-surface utility. Centering each row on its
+            own width left three different edges and read as three things
+            floating; a labelled panel gives them one column to line up in. */}
+        <div className="space-y-4 rounded-lg bg-white dark:bg-neutral-900 p-4 smooth-shadow-ring-xs">
+          {/* A slider, because the five sizes are one ordered scale — dragging
+              up and down it shows the ramp in a way five separate buttons
+              never did. */}
+          {/* No value readout: the class string at the foot of the panel already
+              names the size, and it was the only control that needed a fixed
+              slot to keep the row from shuffling as you drag. */}
+          <Field label="Size">
+            <SizeSlider value={selected} onChange={setSelected} label={size.label} />
+          </Field>
 
-          {/* A plain select next to the swatches: it names what they tint and
-              stays out of the way, where a second segmented control needed a
-              track of its own to hold itself together. */}
-          <div className="flex flex-wrap items-center justify-center gap-3">
-            <select
-              aria-label="Color target"
-              value={activeTarget}
-              onChange={(event) => setTarget(event.target.value as Target)}
-              disabled={!ring}
-              className="cursor-pointer bg-transparent text-xs font-medium text-neutral-900 dark:text-white disabled:cursor-not-allowed disabled:text-neutral-400"
-            >
-              <option value="shadow">Shadow</option>
-              <option value="ring">Ring</option>
-            </select>
+          <Field label="Ring">
+            <Switch checked={ring} onCheckedChange={setRing} label="Ring" />
+          </Field>
 
-            <div className="flex flex-wrap items-center gap-1">
-              {SWATCHES.map(({ hex, token }) => (
-                <motion.button
-                  key={hex}
-                  aria-label={`${activeTarget} ${token}`}
-                  onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
-                  className={cn(
-                    "size-5 rounded-full cursor-pointer border-[1.5px] transition-colors",
-                    colors[activeTarget] === hex
-                      ? "border-black/30 dark:border-white/50"
-                      : "border-black/5 dark:border-white/15 hover:border-black/10 dark:hover:border-white/25"
-                  )}
-                  style={{ backgroundColor: hex }}
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.9 }}
-                  transition={{ type: "spring", stiffness: 500, damping: 28 }}
-                />
-              ))}
+          <Field label="Color" align="start">
+            {/* `w-fit` so the segmented track hugs its two options instead of
+                stretching to fill the control column. */}
+            <div className="w-fit space-y-2">
+              <Segmented>
+                {[
+                  { label: "Shadow", value: "shadow" as Target },
+                  { label: "Ring", value: "ring" as Target },
+                ].map((option) => (
+                  <Segment
+                    key={option.label}
+                    active={activeTarget === option.value}
+                    layoutId="target-selector"
+                    onClick={() => setTarget(option.value)}
+                    // `smooth-ring-*` does nothing without a ring to paint.
+                    disabled={!ring && option.value === "ring"}
+                    dot={colors[option.value]}
+                  >
+                    {option.label}
+                  </Segment>
+                ))}
+              </Segmented>
+
+              {/* Each dot carries a 28px transparent target around it — they
+                  were a pixel hunt at their own 20px size. `-mx-1` pulls that
+                  padding back out so the first dot's *edge* lands on the column,
+                  not its hit area. Wrapping against a 12-target cap rather than
+                  a fixed 12-column grid: it still breaks two-by-twelve at full
+                  width, but reflows to whatever fits once the panel narrows,
+                  where a fixed grid would just overflow. */}
+              <div className="-mx-1 flex w-full max-w-[21.5rem] flex-wrap items-center">
+              {SWATCHES.map(({ hex, token }) => {
+                const active = colors[activeTarget] === hex;
+                return (
+                  <motion.button
+                    key={hex}
+                    type="button"
+                    aria-label={`${activeTarget} ${token}`}
+                    aria-pressed={active}
+                    title={token}
+                    onClick={() => {
+                      picked.current[activeTarget] = true;
+                      setColors((prev) => ({ ...prev, [activeTarget]: hex }));
+                    }}
+                    className="group grid size-7 cursor-pointer place-items-center rounded-full outline-none"
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.9 }}
+                    transition={{ type: "spring", stiffness: 500, damping: 28 }}
+                  >
+                    <span
+                      className={cn(
+                        "size-5 rounded-full border-[1.5px] transition-colors",
+                        active
+                          ? "border-black/5 ring-[1.5px] ring-offset-2 ring-offset-white dark:border-white/15 dark:ring-offset-neutral-900"
+                          : "border-black/5 group-hover:border-black/10 dark:border-white/15 dark:group-hover:border-white/25"
+                      )}
+                      style={{
+                        backgroundColor: hex,
+                        // The swatch's own color rather than a fixed grey, so it
+                        // reads as "this one" instead of a generic marker on top
+                        // of it — contrast-corrected so it can't vanish.
+                        ...(active ? { "--tw-ring-color": ringColor(hex, theme) } : {}),
+                      }}
+                    />
+                  </motion.button>
+                );
+              })}
+              </div>
             </div>
+          </Field>
+
+          {/* The class string is the panel's output, so it lives in the panel —
+              a hairline and the panel's own padding instead of a third bordered
+              box nested inside the second. Not wrapped: a long string truncates
+              under the fade like every other snippet on the page. */}
+          <div className="-mx-4 -mb-4 border-t border-neutral-200 dark:border-neutral-800">
+            <CodeField code={`<div className="${classString}" />`} plain bare />
           </div>
         </div>
-
-        <CodeField code={`<div className="${classString}" />`} wrap plain />
       </div>
     </div>
   );

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -1,4 +1,4 @@
-import { motion, useAnimationControls, useReducedMotion } from "motion/react";
+import { motion } from "motion/react";
 import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { CodeField } from "./code-field";
 import { cn } from "../utils/cn";
@@ -75,7 +75,7 @@ function tokenFor(hex: string) {
    smooth-shadow-ring-xs, so the page is wearing the thing it sells. */
 function Segmented({ children }: { children: ReactNode }) {
   return (
-    <div className="flex items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-950">
+    <div className="flex items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-800">
       {children}
     </div>
   );
@@ -110,7 +110,7 @@ function Segment({
       {active && (
         <motion.span
           layoutId={layoutId}
-          className="absolute inset-0 rounded-full bg-white dark:bg-neutral-800 smooth-shadow-ring-xs"
+          className="absolute inset-0 rounded-full bg-white dark:bg-neutral-700 smooth-shadow-ring-xs"
           transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
         />
       )}
@@ -137,20 +137,6 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
   const activeTarget: Target = ring ? target : "shadow";
   const shadowTinted = colors.shadow !== DEFAULT_SHADOW;
 
-  /* Elevation is a physical claim, so changing it should read as the surface
-     settling into a new height rather than a cross-fade. Both previews dip and
-     spring back together whenever the size or the ring changes — slow in, slow
-     out, with the overshoot doing the follow-through. */
-  const settle = useAnimationControls();
-  const reduceMotion = useReducedMotion();
-  useEffect(() => {
-    if (reduceMotion) return;
-    settle.start({
-      scale: [0.97, 1],
-      transition: { duration: 0.45, ease: [0.34, 1.56, 0.64, 1] },
-    });
-  }, [selected, ring, settle, reduceMotion]);
-
   const size = SIZES[selected];
   const classString = [
     ring ? size.ring : size.smooth,
@@ -163,13 +149,15 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
   return (
     <div className="w-full space-y-5">
       <h2 className="font-medium leading-tight">Try it out</h2>
-      <div className="p-8 rounded-md bg-neutral-50 dark:bg-neutral-900 space-y-6">
-        <div className="flex items-center justify-center gap-8 sm:gap-16 px-4 sm:px-8 py-12 sm:py-16">
+      <div className="p-2 rounded-xl bg-neutral-50 dark:bg-neutral-900 space-y-6">
+        {/* The stage is its own surface, raised off the card, so the demo sits
+            on something rather than floating in the same flat box as the
+            controls. */}
+        <div className="flex items-center justify-center gap-8 sm:gap-16 rounded-lg bg-white dark:bg-neutral-950 px-4 sm:px-8 py-12 sm:py-16 smooth-shadow-ring-xs">
           <div className="flex flex-col items-center gap-3">
-            <motion.div
-              animate={settle}
+            <div
               className={cn(
-                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl shadow-black/10 dark:shadow-white/10 transition-shadow duration-500 ease-out",
+                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl shadow-black/10 dark:shadow-white/10 transition-shadow duration-300",
                 size.tailwind
               )}
               style={
@@ -183,10 +171,9 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
             <span className="text-sm text-neutral-400">Default</span>
           </div>
           <div className="flex flex-col items-center gap-3">
-            <motion.div
-              animate={settle}
+            <div
               className={cn(
-                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-500 ease-out",
+                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-300",
                 ring ? size.ring : size.smooth
               )}
               style={
@@ -202,7 +189,7 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
 
         {/* Controls sit centered under the preview, in two groups: what the
             shadow is, then what color it is. No labels — the options say it. */}
-        <div className="space-y-6">
+        <div className="space-y-5 px-4 pb-4">
           <div className="flex flex-wrap items-center justify-center gap-2">
             <Segmented>
               {SIZES.map((option, i) => (
@@ -233,47 +220,39 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
             </Segmented>
           </div>
 
-          {/* One control, not two: the target picker and its palette share a
-              single track, so what you click and what it applies to are
-              obviously the same widget. The palette scrolls inside the track
-              when the viewport is too narrow for all of it. */}
-          <div className="flex justify-center">
-            <div className="flex max-w-full items-center gap-1.5 rounded-full p-1 bg-neutral-100 dark:bg-neutral-950">
-              <div className="flex shrink-0 items-center gap-0.5">
-                {(["shadow", "ring"] as const).map((key) => (
-                  <Segment
-                    key={key}
-                    active={activeTarget === key}
-                    layoutId="target-selector"
-                    disabled={key === "ring" && !ring}
-                    onClick={() => setTarget(key)}
-                  >
-                    {key === "shadow" ? "Shadow" : "Ring"}
-                  </Segment>
-                ))}
-              </div>
+          {/* A plain select next to the swatches: it names what they tint and
+              stays out of the way, where a second segmented control needed a
+              track of its own to hold itself together. */}
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <select
+              aria-label="Color target"
+              value={activeTarget}
+              onChange={(event) => setTarget(event.target.value as Target)}
+              disabled={!ring}
+              className="cursor-pointer bg-transparent text-xs font-medium text-neutral-900 dark:text-white disabled:cursor-not-allowed disabled:text-neutral-400"
+            >
+              <option value="shadow">Shadow</option>
+              <option value="ring">Ring</option>
+            </select>
 
-              <span className="h-4 w-px shrink-0 bg-neutral-200 dark:bg-neutral-800" />
-
-              <div className="flex items-center gap-1 overflow-x-auto scrollbar-none px-0.5">
-                {SWATCHES.map(({ hex, token }) => (
-                  <motion.button
-                    key={hex}
-                    aria-label={`${activeTarget} ${token}`}
-                    onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
-                    className={cn(
-                      "size-4 shrink-0 rounded-full cursor-pointer border-[1.5px] transition-colors",
-                      colors[activeTarget] === hex
-                        ? "border-black/40 dark:border-white/60"
-                        : "border-black/5 dark:border-white/15 hover:border-black/20 dark:hover:border-white/30"
-                    )}
-                    style={{ backgroundColor: hex }}
-                    whileHover={{ scale: 1.15 }}
-                    whileTap={{ scale: 0.9 }}
-                    transition={{ type: "spring", stiffness: 500, damping: 28 }}
-                  />
-                ))}
-              </div>
+            <div className="flex flex-wrap items-center gap-1">
+              {SWATCHES.map(({ hex, token }) => (
+                <motion.button
+                  key={hex}
+                  aria-label={`${activeTarget} ${token}`}
+                  onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
+                  className={cn(
+                    "size-5 rounded-full cursor-pointer border-[1.5px] transition-colors",
+                    colors[activeTarget] === hex
+                      ? "border-black/30 dark:border-white/50"
+                      : "border-black/5 dark:border-white/15 hover:border-black/10 dark:hover:border-white/25"
+                  )}
+                  style={{ backgroundColor: hex }}
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.9 }}
+                  transition={{ type: "spring", stiffness: 500, damping: 28 }}
+                />
+              ))}
             </div>
           </div>
         </div>

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -1,0 +1,240 @@
+import { motion } from "motion/react";
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import { CodeField } from "./code-field";
+import { cn } from "../utils/cn";
+import type { ResolvedTheme } from "../utils/theme";
+
+const SIZES = [
+  { label: "XS", smooth: "smooth-shadow-xs", ring: "smooth-shadow-ring-xs", tailwind: "shadow-xs" },
+  { label: "SM", smooth: "smooth-shadow-sm", ring: "smooth-shadow-ring-sm", tailwind: "shadow-sm" },
+  { label: "Default", smooth: "smooth-shadow", ring: "smooth-shadow-ring", tailwind: "shadow" },
+  { label: "LG", smooth: "smooth-shadow-lg", ring: "smooth-shadow-ring-lg", tailwind: "shadow-lg" },
+  { label: "XL", smooth: "smooth-shadow-xl", ring: "smooth-shadow-ring-xl", tailwind: "shadow-xl" },
+];
+
+/* Same swatch set as the gradient-border plugin demo, so the two pages feel
+   like one family. Every hex maps to a real Tailwind token, which is what the
+   generated class string below the preview quotes. */
+const SWATCHES: { hex: string; token: string }[] = [
+  { hex: "#ffffff", token: "white" },
+  { hex: "#d4d4d4", token: "neutral-300" },
+  { hex: "#a3a3a3", token: "neutral-400" },
+  { hex: "#525252", token: "neutral-600" },
+  { hex: "#262626", token: "neutral-800" },
+  { hex: "#000000", token: "black" },
+  { hex: "#38bdf8", token: "sky-400" },
+  { hex: "#60a5fa", token: "blue-400" },
+  { hex: "#818cf8", token: "indigo-400" },
+  { hex: "#a78bfa", token: "violet-400" },
+  { hex: "#c084fc", token: "purple-400" },
+  { hex: "#e879f9", token: "fuchsia-400" },
+  { hex: "#f472b6", token: "pink-400" },
+  { hex: "#fb7185", token: "rose-400" },
+  { hex: "#f87171", token: "red-400" },
+  { hex: "#fb923c", token: "orange-400" },
+  { hex: "#fbbf24", token: "amber-400" },
+  { hex: "#a3e635", token: "lime-400" },
+  { hex: "#4ade80", token: "green-400" },
+  { hex: "#34d399", token: "emerald-400" },
+  { hex: "#22d3ee", token: "cyan-400" },
+];
+
+/* The hairline is 1px, so a tinted ring needs real alpha to read at all — but
+   not so much that it turns back into the hard border the plugin exists to
+   avoid. The generated class string quotes this same number. */
+const RING_ALPHA = 30;
+/* Tailwind's own shadows paint the color at full strength, so the comparison
+   box mixes it down to roughly the `shadow-black/10` it ships with. */
+const DEFAULT_SHADOW_ALPHA = 10;
+
+type Target = "shadow" | "ring";
+type Colors = Record<Target, string>;
+
+const LIGHT_DEFAULTS: Colors = { shadow: "#000000", ring: "#d4d4d4" };
+const DARK_DEFAULTS: Colors = { shadow: "#ffffff", ring: "#525252" };
+
+function mix(hex: string, alpha: number) {
+  return `color-mix(in srgb, ${hex} ${alpha}%, transparent)`;
+}
+
+function tokenFor(hex: string) {
+  return SWATCHES.find((swatch) => swatch.hex === hex)?.token ?? `[${hex}]`;
+}
+
+function Pill({
+  active,
+  layoutId,
+  onClick,
+  disabled,
+  children,
+}: {
+  active: boolean;
+  layoutId: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "relative px-3 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-colors",
+        disabled
+          ? "cursor-not-allowed text-neutral-300 dark:text-neutral-700"
+          : active
+            ? "cursor-pointer text-neutral-900 dark:text-white"
+            : "cursor-pointer text-neutral-400 hover:text-neutral-500"
+      )}
+    >
+      {active && (
+        <motion.span
+          layoutId={layoutId}
+          className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-full"
+          transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
+        />
+      )}
+      <span className="relative z-10">{children}</span>
+    </button>
+  );
+}
+
+export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
+  const [selected, setSelected] = useState(2);
+  const [ring, setRing] = useState(true);
+  const [target, setTarget] = useState<Target>("shadow");
+  const [colors, setColors] = useState<Colors>(() =>
+    theme === "dark" ? DARK_DEFAULTS : LIGHT_DEFAULTS
+  );
+
+  // A black shadow is invisible on black, so follow the theme back to sensible
+  // defaults whenever it flips.
+  useEffect(() => {
+    setColors(theme === "dark" ? DARK_DEFAULTS : LIGHT_DEFAULTS);
+  }, [theme]);
+
+  // `smooth-ring-*` does nothing without a ring, so don't offer it as a target.
+  const activeTarget: Target = ring ? target : "shadow";
+
+  const size = SIZES[selected];
+  const classString = [
+    ring ? size.ring : size.smooth,
+    `shadow-${tokenFor(colors.shadow)}`,
+    ring ? `smooth-ring-${tokenFor(colors.ring)}/${RING_ALPHA}` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className="w-full space-y-5">
+      <h2 className="font-medium leading-tight">Try it out</h2>
+      <div className="p-8 rounded-md bg-neutral-50 dark:bg-neutral-900 space-y-6">
+        <div className="flex items-center justify-center gap-8 sm:gap-16 px-4 sm:px-8 py-12 sm:py-16">
+          <div className="flex flex-col items-center gap-3">
+            <div
+              className={cn(
+                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-300",
+                size.tailwind
+              )}
+              style={
+                {
+                  "--tw-shadow-color": mix(colors.shadow, DEFAULT_SHADOW_ALPHA),
+                } as CSSProperties
+              }
+            />
+            <span className="text-sm text-neutral-400">Default</span>
+          </div>
+          <div className="flex flex-col items-center gap-3">
+            <div
+              className={cn(
+                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-300",
+                ring ? size.ring : size.smooth
+              )}
+              style={
+                {
+                  "--tw-shadow-color": colors.shadow,
+                  ...(ring ? { "--smooth-ring-color": mix(colors.ring, RING_ALPHA) } : {}),
+                } as CSSProperties
+              }
+            />
+            <span className="text-sm text-neutral-400">{ring ? "Smooth + ring" : "Smooth"}</span>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-x-1 gap-y-2">
+          <div className="flex items-center gap-1">
+            {SIZES.map((option, i) => (
+              <Pill
+                key={option.label}
+                active={selected === i}
+                layoutId="size-selector"
+                onClick={() => setSelected(i)}
+              >
+                {option.label}
+              </Pill>
+            ))}
+          </div>
+          <span className="hidden sm:block w-px h-4 mx-1.5 bg-neutral-200 dark:bg-neutral-700" />
+          <div className="flex items-center gap-1">
+            {[
+              { label: "Ring", value: true },
+              { label: "No ring", value: false },
+            ].map((option) => (
+              <Pill
+                key={option.label}
+                active={ring === option.value}
+                layoutId="ring-selector"
+                onClick={() => setRing(option.value)}
+              >
+                {option.label}
+              </Pill>
+            ))}
+          </div>
+        </div>
+
+        <div className="h-px bg-neutral-200/70 dark:bg-neutral-800" />
+
+        {/* Color — the ring and the shadow tint independently, so pick a target first */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-neutral-500 dark:text-neutral-400">Color</span>
+            <div className="flex items-center gap-1">
+              {(["shadow", "ring"] as const).map((option) => (
+                <Pill
+                  key={option}
+                  active={activeTarget === option}
+                  layoutId="target-selector"
+                  disabled={option === "ring" && !ring}
+                  onClick={() => setTarget(option)}
+                >
+                  {option === "shadow" ? "Shadow" : "Ring"}
+                </Pill>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {SWATCHES.map(({ hex, token }) => (
+              <motion.button
+                key={hex}
+                aria-label={`${activeTarget} ${token}`}
+                onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
+                className={cn(
+                  "size-5 rounded-full cursor-pointer border-[1.5px] transition-colors",
+                  colors[activeTarget] === hex
+                    ? "border-black/30 dark:border-white/50"
+                    : "border-black/5 dark:border-white/15 hover:border-black/10 dark:hover:border-white/25"
+                )}
+                style={{ backgroundColor: hex }}
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.9 }}
+                transition={{ type: "spring", stiffness: 500, damping: 28 }}
+              />
+            ))}
+          </div>
+        </div>
+
+        <CodeField code={`<div className="${classString}" />`} language="html" wrap />
+      </div>
+    </div>
+  );
+}

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -12,15 +12,18 @@ const SIZES = [
   { label: "XL", smooth: "smooth-shadow-xl", ring: "smooth-shadow-ring-xl", tailwind: "shadow-xl" },
 ];
 
-/* Same swatch set as the gradient-border plugin demo, so the two pages feel
-   like one family. Every hex maps to a real Tailwind token, which is what the
-   generated class string below the preview quotes. */
+/* The gradient-border plugin demo's palette, same swatches in the same order,
+   so the two pages feel like one family. Every hex maps to a real Tailwind
+   token, which is what the generated class string below the preview quotes. */
 const SWATCHES: { hex: string; token: string }[] = [
   { hex: "#ffffff", token: "white" },
+  { hex: "#fafafa", token: "neutral-50" },
   { hex: "#d4d4d4", token: "neutral-300" },
   { hex: "#a3a3a3", token: "neutral-400" },
   { hex: "#525252", token: "neutral-600" },
+  { hex: "#404040", token: "neutral-700" },
   { hex: "#262626", token: "neutral-800" },
+  { hex: "#171717", token: "neutral-900" },
   { hex: "#000000", token: "black" },
   { hex: "#38bdf8", token: "sky-400" },
   { hex: "#60a5fa", token: "blue-400" },
@@ -50,8 +53,14 @@ const DEFAULT_SHADOW_ALPHA = 10;
 type Target = "shadow" | "ring";
 type Colors = Record<Target, string>;
 
-const LIGHT_DEFAULTS: Colors = { shadow: "#000000", ring: "#d4d4d4" };
-const DARK_DEFAULTS: Colors = { shadow: "#ffffff", ring: "#525252" };
+/* The shadow stays black in both themes — that's the plugin's own default, and
+   a white shadow on a dark ground reads as a glow around the box rather than a
+   shadow under it. Only the ring flips, since a black hairline disappears
+   there. Until the shadow is actually tinted we set no color at all, so both
+   previews render exactly what the page shipped with. */
+const DEFAULT_SHADOW = "#000000";
+const LIGHT_DEFAULTS: Colors = { shadow: DEFAULT_SHADOW, ring: "#d4d4d4" };
+const DARK_DEFAULTS: Colors = { shadow: DEFAULT_SHADOW, ring: "#525252" };
 
 function mix(hex: string, alpha: number) {
   return `color-mix(in srgb, ${hex} ${alpha}%, transparent)`;
@@ -65,26 +74,19 @@ function Pill({
   active,
   layoutId,
   onClick,
-  disabled,
   children,
 }: {
   active: boolean;
   layoutId: string;
   onClick: () => void;
-  disabled?: boolean;
   children: ReactNode;
 }) {
   return (
     <button
       onClick={onClick}
-      disabled={disabled}
       className={cn(
-        "relative px-3 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-colors",
-        disabled
-          ? "cursor-not-allowed text-neutral-300 dark:text-neutral-700"
-          : active
-            ? "cursor-pointer text-neutral-900 dark:text-white"
-            : "cursor-pointer text-neutral-400 hover:text-neutral-500"
+        "relative px-3 py-1 cursor-pointer rounded-full text-xs font-medium whitespace-nowrap transition-colors",
+        active ? "text-neutral-900 dark:text-white" : "text-neutral-400 hover:text-neutral-500"
       )}
     >
       {active && (
@@ -107,14 +109,15 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
     theme === "dark" ? DARK_DEFAULTS : LIGHT_DEFAULTS
   );
 
-  // A black shadow is invisible on black, so follow the theme back to sensible
-  // defaults whenever it flips.
+  // A black hairline is invisible on black, so follow the theme back to
+  // sensible defaults whenever it flips.
   useEffect(() => {
     setColors(theme === "dark" ? DARK_DEFAULTS : LIGHT_DEFAULTS);
   }, [theme]);
 
   // `smooth-ring-*` does nothing without a ring, so don't offer it as a target.
   const activeTarget: Target = ring ? target : "shadow";
+  const shadowTinted = colors.shadow !== DEFAULT_SHADOW;
 
   const size = SIZES[selected];
   const classString = [
@@ -133,13 +136,15 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
           <div className="flex flex-col items-center gap-3">
             <div
               className={cn(
-                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-300",
+                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl shadow-black/10 dark:shadow-white/10 transition-shadow duration-300",
                 size.tailwind
               )}
               style={
-                {
-                  "--tw-shadow-color": mix(colors.shadow, DEFAULT_SHADOW_ALPHA),
-                } as CSSProperties
+                shadowTinted
+                  ? ({
+                      "--tw-shadow-color": mix(colors.shadow, DEFAULT_SHADOW_ALPHA),
+                    } as CSSProperties)
+                  : undefined
               }
             />
             <span className="text-sm text-neutral-400">Default</span>
@@ -152,7 +157,7 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
               )}
               style={
                 {
-                  "--tw-shadow-color": colors.shadow,
+                  ...(shadowTinted ? { "--tw-shadow-color": colors.shadow } : {}),
                   ...(ring ? { "--smooth-ring-color": mix(colors.ring, RING_ALPHA) } : {}),
                 } as CSSProperties
               }
@@ -174,7 +179,7 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
               </Pill>
             ))}
           </div>
-          <span className="hidden sm:block w-px h-4 mx-1.5 bg-neutral-200 dark:bg-neutral-700" />
+          <span className="hidden sm:block shrink-0 w-px h-4 mx-1.5 bg-neutral-200 dark:bg-neutral-700" />
           <div className="flex items-center gap-1">
             {[
               { label: "Ring", value: true },
@@ -194,25 +199,39 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
 
         <div className="h-px bg-neutral-200/70 dark:bg-neutral-800" />
 
-        {/* Color — the ring and the shadow tint independently, so pick a target first */}
+        {/* Color — the ring and the shadow tint independently, so pick a target first.
+            Same selector and swatch grid as the gradient-border plugin demo. */}
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <span className="text-sm text-neutral-500 dark:text-neutral-400">Color</span>
+            <span className="text-sm text-neutral-500">Color</span>
             <div className="flex items-center gap-1">
-              {(["shadow", "ring"] as const).map((option) => (
-                <Pill
-                  key={option}
-                  active={activeTarget === option}
-                  layoutId="target-selector"
-                  disabled={option === "ring" && !ring}
-                  onClick={() => setTarget(option)}
+              {(["shadow", "ring"] as const).map((key) => (
+                <button
+                  key={key}
+                  onClick={() => setTarget(key)}
+                  disabled={key === "ring" && !ring}
+                  className={cn(
+                    "relative text-xs px-2 py-0.5 rounded-md transition-colors",
+                    key === "ring" && !ring
+                      ? "cursor-not-allowed text-neutral-300 dark:text-neutral-700"
+                      : activeTarget === key
+                        ? "cursor-pointer text-neutral-900 dark:text-white font-medium"
+                        : "cursor-pointer text-neutral-400 hover:text-neutral-500"
+                  )}
                 >
-                  {option === "shadow" ? "Shadow" : "Ring"}
-                </Pill>
+                  {activeTarget === key && (
+                    <motion.span
+                      layoutId="target-bg"
+                      className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-md"
+                      transition={{ type: "spring", duration: 0.35, bounce: 0.15 }}
+                    />
+                  )}
+                  <span className="relative z-10">{key}</span>
+                </button>
               ))}
             </div>
           </div>
-          <div className="flex flex-wrap gap-1">
+          <div className="flex gap-1 flex-wrap">
             {SWATCHES.map(({ hex, token }) => (
               <motion.button
                 key={hex}

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -70,19 +70,18 @@ function tokenFor(hex: string) {
   return SWATCHES.find((swatch) => swatch.hex === hex)?.token ?? `[${hex}]`;
 }
 
-/* One row per decision: name on the left, its options on the right. Same shape
-   as the gradient-border configurator's "Stops" row, so every control on the
-   page reads on a single axis instead of three. */
-function Control({ label, children }: { label: string; children: ReactNode }) {
+/* A real segmented control rather than a row of text buttons: a sunken track
+   with one raised thumb that slides between options. The thumb is a
+   smooth-shadow-ring-xs, so the page is wearing the thing it sells. */
+function Segmented({ children }: { children: ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-sm text-neutral-500">{label}</span>
-      <div className="flex items-center gap-1">{children}</div>
+    <div className="flex items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-800">
+      {children}
     </div>
   );
 }
 
-function Option({
+function Segment({
   active,
   layoutId,
   onClick,
@@ -100,19 +99,19 @@ function Option({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "relative text-xs px-2 py-0.5 rounded-md whitespace-nowrap transition-colors",
+        "relative rounded-full px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-colors",
         disabled
-          ? "cursor-not-allowed text-neutral-300 dark:text-neutral-700"
+          ? "cursor-not-allowed text-neutral-300 dark:text-neutral-600"
           : active
-            ? "cursor-pointer text-neutral-900 dark:text-white font-medium"
-            : "cursor-pointer text-neutral-400 hover:text-neutral-500"
+            ? "cursor-pointer text-neutral-900 dark:text-white"
+            : "cursor-pointer text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200"
       )}
     >
       {active && (
         <motion.span
           layoutId={layoutId}
-          className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-md"
-          transition={{ type: "spring", duration: 0.35, bounce: 0.15 }}
+          className="absolute inset-0 rounded-full bg-white dark:bg-neutral-700 smooth-shadow-ring-xs"
+          transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
         />
       )}
       <span className="relative z-10">{children}</span>
@@ -185,70 +184,75 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
           </div>
         </div>
 
-        {/* One decision per row — size, then ring, then which of the two the
-            swatches below are tinting. */}
-        <div className="space-y-3">
-          <Control label="Size">
-            {SIZES.map((option, i) => (
-              <Option
-                key={option.label}
-                active={selected === i}
-                layoutId="size-selector"
-                onClick={() => setSelected(i)}
-              >
-                {option.label}
-              </Option>
-            ))}
-          </Control>
+        {/* Controls sit centered under the preview, in two groups: what the
+            shadow is, then what color it is. No labels — the options say it. */}
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <Segmented>
+              {SIZES.map((option, i) => (
+                <Segment
+                  key={option.label}
+                  active={selected === i}
+                  layoutId="size-selector"
+                  onClick={() => setSelected(i)}
+                >
+                  {option.label}
+                </Segment>
+              ))}
+            </Segmented>
+            <Segmented>
+              {[
+                { label: "Ring", value: true },
+                { label: "No ring", value: false },
+              ].map((option) => (
+                <Segment
+                  key={option.label}
+                  active={ring === option.value}
+                  layoutId="ring-selector"
+                  onClick={() => setRing(option.value)}
+                >
+                  {option.label}
+                </Segment>
+              ))}
+            </Segmented>
+          </div>
 
-          <Control label="Ring">
-            {[
-              { label: "on", value: true },
-              { label: "off", value: false },
-            ].map((option) => (
-              <Option
-                key={option.label}
-                active={ring === option.value}
-                layoutId="ring-selector"
-                onClick={() => setRing(option.value)}
-              >
-                {option.label}
-              </Option>
-            ))}
-          </Control>
+          <div className="space-y-2.5">
+            <div className="flex justify-center">
+              <Segmented>
+                {(["shadow", "ring"] as const).map((key) => (
+                  <Segment
+                    key={key}
+                    active={activeTarget === key}
+                    layoutId="target-selector"
+                    disabled={key === "ring" && !ring}
+                    onClick={() => setTarget(key)}
+                  >
+                    {key === "shadow" ? "Shadow" : "Ring"}
+                  </Segment>
+                ))}
+              </Segmented>
+            </div>
 
-          <Control label="Color">
-            {(["shadow", "ring"] as const).map((key) => (
-              <Option
-                key={key}
-                active={activeTarget === key}
-                layoutId="target-selector"
-                disabled={key === "ring" && !ring}
-                onClick={() => setTarget(key)}
-              >
-                {key}
-              </Option>
-            ))}
-          </Control>
-
-          <div className="flex gap-1 flex-wrap">
-            {SWATCHES.map(({ hex, token }) => (
-              <motion.button
-                key={hex}
-                aria-label={`${activeTarget} ${token}`}
-                onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
-                className={cn(
-                  "size-5 rounded-full cursor-pointer border-[1.5px] transition-colors",
-                  colors[activeTarget] === hex
-                    ? "border-black/30 dark:border-white/50"
-                    : "border-black/5 dark:border-white/15 hover:border-black/10 dark:hover:border-white/25"
-                )}
-                style={{ backgroundColor: hex }}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.9 }}
-                transition={{ type: "spring", stiffness: 500, damping: 28 }}
-              />
-            ))}
+            <div className="flex flex-wrap justify-center gap-1">
+              {SWATCHES.map(({ hex, token }) => (
+                <motion.button
+                  key={hex}
+                  aria-label={`${activeTarget} ${token}`}
+                  onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
+                  className={cn(
+                    "size-5 rounded-full cursor-pointer border-[1.5px] transition-colors",
+                    colors[activeTarget] === hex
+                      ? "border-black/30 dark:border-white/50"
+                      : "border-black/5 dark:border-white/15 hover:border-black/10 dark:hover:border-white/25"
+                  )}
+                  style={{ backgroundColor: hex }}
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.9 }}
+                  transition={{ type: "spring", stiffness: 500, damping: 28 }}
+                />
+              ))}
+            </div>
           </div>
         </div>
 

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -1,4 +1,4 @@
-import { motion } from "motion/react";
+import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { CodeField } from "./code-field";
 import { cn } from "../utils/cn";
@@ -137,6 +137,20 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
   const activeTarget: Target = ring ? target : "shadow";
   const shadowTinted = colors.shadow !== DEFAULT_SHADOW;
 
+  /* Elevation is a physical claim, so changing it should read as the surface
+     settling into a new height rather than a cross-fade. Both previews dip and
+     spring back together whenever the size or the ring changes — slow in, slow
+     out, with the overshoot doing the follow-through. */
+  const settle = useAnimationControls();
+  const reduceMotion = useReducedMotion();
+  useEffect(() => {
+    if (reduceMotion) return;
+    settle.start({
+      scale: [0.97, 1],
+      transition: { duration: 0.45, ease: [0.34, 1.56, 0.64, 1] },
+    });
+  }, [selected, ring, settle, reduceMotion]);
+
   const size = SIZES[selected];
   const classString = [
     ring ? size.ring : size.smooth,
@@ -152,9 +166,10 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
       <div className="p-8 rounded-md bg-neutral-50 dark:bg-neutral-900 space-y-6">
         <div className="flex items-center justify-center gap-8 sm:gap-16 px-4 sm:px-8 py-12 sm:py-16">
           <div className="flex flex-col items-center gap-3">
-            <div
+            <motion.div
+              animate={settle}
               className={cn(
-                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl shadow-black/10 dark:shadow-white/10 transition-shadow duration-300",
+                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl shadow-black/10 dark:shadow-white/10 transition-shadow duration-500 ease-out",
                 size.tailwind
               )}
               style={
@@ -168,9 +183,10 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
             <span className="text-sm text-neutral-400">Default</span>
           </div>
           <div className="flex flex-col items-center gap-3">
-            <div
+            <motion.div
+              animate={settle}
               className={cn(
-                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-300",
+                "size-24 sm:size-32 bg-white dark:bg-neutral-800 rounded-2xl transition-shadow duration-500 ease-out",
                 ring ? size.ring : size.smooth
               )}
               style={

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -252,7 +252,7 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
           </div>
         </div>
 
-        <CodeField code={`<div className="${classString}" />`} language="html" wrap />
+        <CodeField code={`<div className="${classString}" />`} wrap plain />
       </div>
     </div>
   );

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -75,7 +75,7 @@ function tokenFor(hex: string) {
    smooth-shadow-ring-xs, so the page is wearing the thing it sells. */
 function Segmented({ children }: { children: ReactNode }) {
   return (
-    <div className="flex items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-800">
+    <div className="flex items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-950">
       {children}
     </div>
   );
@@ -110,7 +110,7 @@ function Segment({
       {active && (
         <motion.span
           layoutId={layoutId}
-          className="absolute inset-0 rounded-full bg-white dark:bg-neutral-700 smooth-shadow-ring-xs"
+          className="absolute inset-0 rounded-full bg-white dark:bg-neutral-800 smooth-shadow-ring-xs"
           transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
         />
       )}
@@ -217,12 +217,13 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
             </Segmented>
           </div>
 
-          {/* Each segment carries a dot of the color it currently holds, so the
-              swatch you click visibly lands in the selected one — that is what
-              ties this control to the row underneath it. */}
-          <div className="space-y-2">
-            <div className="flex justify-center">
-              <Segmented>
+          {/* One control, not two: the target picker and its palette share a
+              single track, so what you click and what it applies to are
+              obviously the same widget. The palette scrolls inside the track
+              when the viewport is too narrow for all of it. */}
+          <div className="flex justify-center">
+            <div className="flex max-w-full items-center gap-1.5 rounded-full p-1 bg-neutral-100 dark:bg-neutral-950">
+              <div className="flex shrink-0 items-center gap-0.5">
                 {(["shadow", "ring"] as const).map((key) => (
                   <Segment
                     key={key}
@@ -231,43 +232,32 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
                     disabled={key === "ring" && !ring}
                     onClick={() => setTarget(key)}
                   >
-                    <span className="flex items-center gap-1.5">
-                      <span
-                        className={cn(
-                          "size-2.5 rounded-full ring-1 transition-colors",
-                          key === "ring" && !ring
-                            ? "bg-transparent ring-neutral-300 dark:ring-neutral-600"
-                            : "ring-black/15 dark:ring-white/25"
-                        )}
-                        style={
-                          key === "ring" && !ring ? undefined : { backgroundColor: colors[key] }
-                        }
-                      />
-                      {key === "shadow" ? "Shadow" : "Ring"}
-                    </span>
+                    {key === "shadow" ? "Shadow" : "Ring"}
                   </Segment>
                 ))}
-              </Segmented>
-            </div>
+              </div>
 
-            <div className="flex flex-wrap justify-center gap-1">
-              {SWATCHES.map(({ hex, token }) => (
-                <motion.button
-                  key={hex}
-                  aria-label={`${activeTarget} ${token}`}
-                  onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
-                  className={cn(
-                    "size-5 rounded-full cursor-pointer border-[1.5px] transition-colors",
-                    colors[activeTarget] === hex
-                      ? "border-black/30 dark:border-white/50"
-                      : "border-black/5 dark:border-white/15 hover:border-black/10 dark:hover:border-white/25"
-                  )}
-                  style={{ backgroundColor: hex }}
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.9 }}
-                  transition={{ type: "spring", stiffness: 500, damping: 28 }}
-                />
-              ))}
+              <span className="h-4 w-px shrink-0 bg-neutral-200 dark:bg-neutral-800" />
+
+              <div className="flex items-center gap-1 overflow-x-auto scrollbar-none px-0.5">
+                {SWATCHES.map(({ hex, token }) => (
+                  <motion.button
+                    key={hex}
+                    aria-label={`${activeTarget} ${token}`}
+                    onClick={() => setColors((prev) => ({ ...prev, [activeTarget]: hex }))}
+                    className={cn(
+                      "size-4 shrink-0 rounded-full cursor-pointer border-[1.5px] transition-colors",
+                      colors[activeTarget] === hex
+                        ? "border-black/40 dark:border-white/60"
+                        : "border-black/5 dark:border-white/15 hover:border-black/20 dark:hover:border-white/30"
+                    )}
+                    style={{ backgroundColor: hex }}
+                    whileHover={{ scale: 1.15 }}
+                    whileTap={{ scale: 0.9 }}
+                    transition={{ type: "spring", stiffness: 500, damping: 28 }}
+                  />
+                ))}
+              </div>
             </div>
           </div>
         </div>

--- a/demo/src/components/shadow-playground.tsx
+++ b/demo/src/components/shadow-playground.tsx
@@ -70,30 +70,49 @@ function tokenFor(hex: string) {
   return SWATCHES.find((swatch) => swatch.hex === hex)?.token ?? `[${hex}]`;
 }
 
-function Pill({
+/* One row per decision: name on the left, its options on the right. Same shape
+   as the gradient-border configurator's "Stops" row, so every control on the
+   page reads on a single axis instead of three. */
+function Control({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm text-neutral-500">{label}</span>
+      <div className="flex items-center gap-1">{children}</div>
+    </div>
+  );
+}
+
+function Option({
   active,
   layoutId,
   onClick,
+  disabled,
   children,
 }: {
   active: boolean;
   layoutId: string;
   onClick: () => void;
+  disabled?: boolean;
   children: ReactNode;
 }) {
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
       className={cn(
-        "relative px-3 py-1 cursor-pointer rounded-full text-xs font-medium whitespace-nowrap transition-colors",
-        active ? "text-neutral-900 dark:text-white" : "text-neutral-400 hover:text-neutral-500"
+        "relative text-xs px-2 py-0.5 rounded-md whitespace-nowrap transition-colors",
+        disabled
+          ? "cursor-not-allowed text-neutral-300 dark:text-neutral-700"
+          : active
+            ? "cursor-pointer text-neutral-900 dark:text-white font-medium"
+            : "cursor-pointer text-neutral-400 hover:text-neutral-500"
       )}
     >
       {active && (
         <motion.span
           layoutId={layoutId}
-          className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-full"
-          transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
+          className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-md"
+          transition={{ type: "spring", duration: 0.35, bounce: 0.15 }}
         />
       )}
       <span className="relative z-10">{children}</span>
@@ -166,71 +185,52 @@ export function ShadowPlayground({ theme }: { theme: ResolvedTheme }) {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-center gap-x-1 gap-y-2">
-          <div className="flex items-center gap-1">
+        {/* One decision per row — size, then ring, then which of the two the
+            swatches below are tinting. */}
+        <div className="space-y-3">
+          <Control label="Size">
             {SIZES.map((option, i) => (
-              <Pill
+              <Option
                 key={option.label}
                 active={selected === i}
                 layoutId="size-selector"
                 onClick={() => setSelected(i)}
               >
                 {option.label}
-              </Pill>
+              </Option>
             ))}
-          </div>
-          <span className="hidden sm:block shrink-0 w-px h-4 mx-1.5 bg-neutral-200 dark:bg-neutral-700" />
-          <div className="flex items-center gap-1">
+          </Control>
+
+          <Control label="Ring">
             {[
-              { label: "Ring", value: true },
-              { label: "No ring", value: false },
+              { label: "on", value: true },
+              { label: "off", value: false },
             ].map((option) => (
-              <Pill
+              <Option
                 key={option.label}
                 active={ring === option.value}
                 layoutId="ring-selector"
                 onClick={() => setRing(option.value)}
               >
                 {option.label}
-              </Pill>
+              </Option>
             ))}
-          </div>
-        </div>
+          </Control>
 
-        <div className="h-px bg-neutral-200/70 dark:bg-neutral-800" />
+          <Control label="Color">
+            {(["shadow", "ring"] as const).map((key) => (
+              <Option
+                key={key}
+                active={activeTarget === key}
+                layoutId="target-selector"
+                disabled={key === "ring" && !ring}
+                onClick={() => setTarget(key)}
+              >
+                {key}
+              </Option>
+            ))}
+          </Control>
 
-        {/* Color — the ring and the shadow tint independently, so pick a target first.
-            Same selector and swatch grid as the gradient-border plugin demo. */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-neutral-500">Color</span>
-            <div className="flex items-center gap-1">
-              {(["shadow", "ring"] as const).map((key) => (
-                <button
-                  key={key}
-                  onClick={() => setTarget(key)}
-                  disabled={key === "ring" && !ring}
-                  className={cn(
-                    "relative text-xs px-2 py-0.5 rounded-md transition-colors",
-                    key === "ring" && !ring
-                      ? "cursor-not-allowed text-neutral-300 dark:text-neutral-700"
-                      : activeTarget === key
-                        ? "cursor-pointer text-neutral-900 dark:text-white font-medium"
-                        : "cursor-pointer text-neutral-400 hover:text-neutral-500"
-                  )}
-                >
-                  {activeTarget === key && (
-                    <motion.span
-                      layoutId="target-bg"
-                      className="absolute inset-0 bg-neutral-100 dark:bg-neutral-800 rounded-md"
-                      transition={{ type: "spring", duration: 0.35, bounce: 0.15 }}
-                    />
-                  )}
-                  <span className="relative z-10">{key}</span>
-                </button>
-              ))}
-            </div>
-          </div>
           <div className="flex gap-1 flex-wrap">
             {SWATCHES.map(({ hex, token }) => (
               <motion.button

--- a/demo/src/components/theme-toggle.tsx
+++ b/demo/src/components/theme-toggle.tsx
@@ -1,0 +1,103 @@
+import { motion } from "motion/react";
+import { cn } from "../utils/cn";
+import type { Theme } from "../utils/theme";
+
+function IconSun({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      aria-hidden
+      className={className}
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2.5v2M12 19.5v2M2.5 12h2M19.5 12h2M5.3 5.3l1.4 1.4M17.3 17.3l1.4 1.4M18.7 5.3l-1.4 1.4M6.7 17.3l-1.4 1.4" />
+    </svg>
+  );
+}
+
+function IconMoon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={className}
+    >
+      <path d="M20 14.2A8.2 8.2 0 0 1 9.8 4 8.2 8.2 0 1 0 20 14.2Z" />
+    </svg>
+  );
+}
+
+function IconSystem({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={className}
+    >
+      <rect x="2.75" y="4.25" width="18.5" height="12.5" rx="2.25" />
+      <path d="M8.5 20.25h7" />
+    </svg>
+  );
+}
+
+const OPTIONS: { value: Theme; label: string; Icon: typeof IconSun }[] = [
+  { value: "system", label: "System theme", Icon: IconSystem },
+  { value: "light", label: "Light theme", Icon: IconSun },
+  { value: "dark", label: "Dark theme", Icon: IconMoon },
+];
+
+export function ThemeToggle({
+  theme,
+  onChange,
+}: {
+  theme: Theme;
+  onChange: (theme: Theme) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme"
+      className="flex shrink-0 items-center gap-0.5 rounded-full p-0.5 bg-neutral-100 dark:bg-neutral-900"
+    >
+      {OPTIONS.map(({ value, label, Icon }) => (
+        <button
+          key={value}
+          role="radio"
+          aria-checked={theme === value}
+          aria-label={label}
+          title={label}
+          onClick={() => onChange(value)}
+          className={cn(
+            "relative grid size-7 cursor-pointer place-items-center rounded-full transition-colors",
+            theme === value
+              ? "text-neutral-900 dark:text-white"
+              : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200"
+          )}
+        >
+          {theme === value && (
+            <motion.span
+              layoutId="theme-toggle"
+              className="absolute inset-0 rounded-full bg-white dark:bg-neutral-800 smooth-shadow-ring-xs"
+              transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
+            />
+          )}
+          <Icon className="relative z-10 size-3.5" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/demo/src/components/theme-toggle.tsx
+++ b/demo/src/components/theme-toggle.tsx
@@ -1,61 +1,14 @@
+import {
+  IconDevices,
+  IconMoon,
+  IconSun,
+} from "@central-icons-react/round-outlined-radius-1-stroke-2";
 import { motion } from "motion/react";
 import { cn } from "../utils/cn";
 import type { Theme } from "../utils/theme";
 
-function IconSun({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.75}
-      strokeLinecap="round"
-      aria-hidden
-      className={className}
-    >
-      <circle cx="12" cy="12" r="4" />
-      <path d="M12 2.5v2M12 19.5v2M2.5 12h2M19.5 12h2M5.3 5.3l1.4 1.4M17.3 17.3l1.4 1.4M18.7 5.3l-1.4 1.4M6.7 17.3l-1.4 1.4" />
-    </svg>
-  );
-}
-
-function IconMoon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.75}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-      className={className}
-    >
-      <path d="M20 14.2A8.2 8.2 0 0 1 9.8 4 8.2 8.2 0 1 0 20 14.2Z" />
-    </svg>
-  );
-}
-
-function IconSystem({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.75}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-      className={className}
-    >
-      <rect x="2.75" y="4.25" width="18.5" height="12.5" rx="2.25" />
-      <path d="M8.5 20.25h7" />
-    </svg>
-  );
-}
-
 const OPTIONS: { value: Theme; label: string; Icon: typeof IconSun }[] = [
-  { value: "system", label: "System theme", Icon: IconSystem },
+  { value: "system", label: "System theme", Icon: IconDevices },
   { value: "light", label: "Light theme", Icon: IconSun },
   { value: "dark", label: "Dark theme", Icon: IconMoon },
 ];
@@ -95,7 +48,7 @@ export function ThemeToggle({
               transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
             />
           )}
-          <Icon className="relative z-10 size-3.5" />
+          <Icon size={14} className="relative z-10" />
         </button>
       ))}
     </div>

--- a/demo/src/components/theme-toggle.tsx
+++ b/demo/src/components/theme-toggle.tsx
@@ -1,8 +1,6 @@
-import {
-  IconDevices,
-  IconMoon,
-  IconSun,
-} from "@central-icons-react/round-outlined-radius-1-stroke-2";
+import { IconDevices } from "@central-icons-react/round-outlined-radius-1-stroke-2/IconDevices";
+import { IconMoon } from "@central-icons-react/round-outlined-radius-1-stroke-2/IconMoon";
+import { IconSun } from "@central-icons-react/round-outlined-radius-1-stroke-2/IconSun";
 import { motion } from "motion/react";
 import { cn } from "../utils/cn";
 import type { Theme } from "../utils/theme";

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -1,6 +1,11 @@
 @import "tailwindcss";
 @import "../../src/index.css";
 
+/* Drive `dark:` off a class instead of the media query, so the toggle in the
+   header can override the system setting. The inline script in index.html puts
+   the class on <html> before the first paint. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* Brand fonts, served from cdn.floriankiem.com (see flornkm/cdn).
    Haas Recast is licensed (Dalton Maag, Host & Link) — do not copy
    the font files into this repo. */
@@ -33,12 +38,10 @@ body {
 
 /* Invert the smooth-shadow ring hairline in dark mode: a transparent white
    edge instead of the default transparent black (which vanishes on dark
-   backgrounds). The plugin redefines --smooth-ring-color under a `.dark`
-   class; this demo uses media-query dark mode, so wire it up here. */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --smooth-ring-color: rgba(255, 255, 255, 0.14);
-  }
+   backgrounds). The plugin already flips it under `.dark`; this just nudges
+   the opacity up a little for this page. */
+.dark {
+  --smooth-ring-color: rgba(255, 255, 255, 0.14);
 }
 
 h1,

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -53,6 +53,75 @@ h6 {
   @apply -tracking-[0.0075em];
 }
 
+/* The playground's size control. The visible track, fill and thumb are real
+   elements so motion can spring them and the hover halo actually transitions —
+   `::-webkit-slider-thumb` ignores transitions in WebKit, which is why the
+   pseudo-element version sat there frozen. The native input stays on top at
+   zero opacity purely to keep dragging, keyboard and a11y for free. */
+.size-slider {
+  --slider-fill: var(--color-neutral-900);
+  --slider-track: var(--color-neutral-200);
+  --slider-halo: rgba(0, 0, 0, 0.06);
+}
+
+.dark .size-slider {
+  --slider-fill: var(--color-neutral-300);
+  --slider-track: var(--color-neutral-800);
+  --slider-halo: rgba(255, 255, 255, 0.1);
+}
+
+/* The track lifts a step on hover so the control announces itself as draggable
+   before you've touched it. */
+.size-slider:hover {
+  --slider-track: var(--color-neutral-300);
+}
+
+.dark .size-slider:hover {
+  --slider-track: var(--color-neutral-700);
+}
+
+.size-slider-thumb {
+  background: var(--color-white);
+  box-shadow:
+    0 0 4px 0 rgba(0, 0, 0, 0.04),
+    0 0 0 1px var(--smooth-ring-color),
+    0 0 0 0 var(--slider-halo);
+  transition: box-shadow 150ms ease-out;
+}
+
+.size-slider:hover .size-slider-thumb,
+.size-slider:focus-within .size-slider-thumb {
+  box-shadow:
+    0 0 4px 0 rgba(0, 0, 0, 0.04),
+    0 0 0 1px var(--smooth-ring-color),
+    0 0 0 3px var(--slider-halo);
+}
+
+/* Hide the native control entirely — it only supplies the interaction. */
+.size-slider-input {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  cursor: grab;
+}
+
+.size-slider-input:active {
+  cursor: grabbing;
+}
+
+.size-slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+}
+
+.size-slider-input::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border: none;
+}
+
 .scrollbar-none {
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/demo/src/utils/highlight.tsx
+++ b/demo/src/utils/highlight.tsx
@@ -1,0 +1,175 @@
+import { Fragment, type ReactNode } from "react";
+
+/*
+ * A ~200 line tokenizer instead of a highlighter dependency. The snippets on
+ * this page are a handful of one-liners plus two markdown files, so the goal is
+ * a hint of color, not full language coverage: three accents (violet for
+ * keywords and tags, emerald for strings and values, sky for identifiers) on a
+ * neutral base, with punctuation dropped back so the code reads as one block.
+ */
+
+const KIND_CLASS = {
+  punct: "text-neutral-300 dark:text-neutral-600",
+  keyword: "text-violet-600 dark:text-violet-400",
+  string: "text-emerald-700 dark:text-emerald-400",
+  ident: "text-sky-700 dark:text-sky-400",
+  heading: "font-medium text-neutral-900 dark:text-white",
+  strong: "text-neutral-900 dark:text-neutral-100",
+  muted: "text-neutral-400 dark:text-neutral-500",
+} as const;
+
+type Kind = keyof typeof KIND_CLASS;
+type Token = { t: string; k?: Kind };
+
+export type Language = "shell" | "css" | "html" | "markdown";
+
+/* ------------------------------------------------------------------ */
+/*  Scanner                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Walks `src` with `re`, handing each match to `map` and passing the gaps through as plain text. */
+function scan(src: string, re: RegExp, map: (m: RegExpExecArray) => Token[]): Token[] {
+  const out: Token[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  re.lastIndex = 0;
+  while ((m = re.exec(src))) {
+    if (m.index > last) out.push({ t: src.slice(last, m.index) });
+    out.push(...map(m));
+    last = m.index + m[0].length;
+    if (m[0] === "") re.lastIndex++; // guard against a zero-width match looping
+  }
+  if (last < src.length) out.push({ t: src.slice(last) });
+  return out;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Languages                                                          */
+/* ------------------------------------------------------------------ */
+
+function tokenizeShell(src: string): Token[] {
+  let word = 0;
+  return src.split(/(\s+)/).map((part) => {
+    if (!part.trim()) return { t: part };
+    word++;
+    // `npm i`, `bun add` — binary then subcommand, everything after is an argument.
+    if (word === 1) return { t: part, k: "keyword" };
+    if (word === 2 || part.startsWith("-")) return { t: part, k: "ident" };
+    return { t: part };
+  });
+}
+
+const CSS_RE =
+  /(\/\*[\s\S]*?\*\/)|(@[\w-]+)|("[^"]*"|'[^']*')|(--[\w-]+)|(\bvar\b)|([{}();:,])|(\b\d+(?:\.\d+)?[a-z%]*)/g;
+
+function tokenizeCss(src: string): Token[] {
+  return scan(src, CSS_RE, (m) => {
+    const [t, comment, atRule, string, customProp, varFn, punct] = m;
+    if (comment) return [{ t, k: "muted" }];
+    if (atRule) return [{ t, k: "keyword" }];
+    if (string) return [{ t, k: "string" }];
+    if (customProp) return [{ t, k: "ident" }];
+    if (varFn) return [{ t, k: "keyword" }];
+    if (punct) return [{ t, k: "punct" }];
+    return [{ t, k: "string" }]; // number
+  });
+}
+
+const HTML_RE = /(<\/?)([\w.-]+)|(\/?>)|([\w:.-]+)(?=\s*=)|(=)|("[^"]*"|'[^']*')/g;
+
+function tokenizeHtml(src: string): Token[] {
+  return scan(src, HTML_RE, (m) => {
+    const [t, open, tag, close, attr, equals, string] = m;
+    if (open)
+      return [
+        { t: open, k: "punct" },
+        { t: tag, k: "keyword" },
+      ];
+    if (close) return [{ t, k: "punct" }];
+    if (attr) return [{ t, k: "ident" }];
+    if (equals) return [{ t, k: "punct" }];
+    if (string) return [{ t, k: "string" }];
+    return [{ t }];
+  });
+}
+
+const MD_INLINE_RE = /(`[^`\n]+`)|(\*\*[^*\n]+\*\*)/g;
+
+function tokenizeMarkdownInline(src: string): Token[] {
+  return scan(src, MD_INLINE_RE, (m) => [{ t: m[0], k: m[1] ? "string" : "strong" }]);
+}
+
+function tokenizeMarkdown(src: string): Token[] {
+  const out: Token[] = [];
+  let inFrontmatter = false;
+
+  src.split("\n").forEach((line, i) => {
+    if (i) out.push({ t: "\n" });
+
+    if (/^---\s*$/.test(line)) {
+      // Opening fence only counts on the first line; the next `---` closes it.
+      if (i === 0) inFrontmatter = true;
+      else if (inFrontmatter) inFrontmatter = false;
+      out.push({ t: line, k: "punct" });
+      return;
+    }
+
+    if (inFrontmatter) {
+      const kv = /^([\w-]+)(:)(.*)$/.exec(line);
+      if (kv) {
+        out.push({ t: kv[1], k: "ident" }, { t: kv[2], k: "punct" }, { t: kv[3] });
+        return;
+      }
+      out.push({ t: line });
+      return;
+    }
+
+    const heading = /^(#{1,6})(\s+)(.*)$/.exec(line);
+    if (heading) {
+      out.push({ t: heading[1], k: "punct" }, { t: heading[2] }, { t: heading[3], k: "heading" });
+      return;
+    }
+
+    const bullet = /^(\s*)([-*])(\s+)(.*)$/.exec(line);
+    if (bullet) {
+      out.push({ t: bullet[1] }, { t: bullet[2], k: "punct" }, { t: bullet[3] });
+      out.push(...tokenizeMarkdownInline(bullet[4]));
+      return;
+    }
+
+    out.push(...tokenizeMarkdownInline(line));
+  });
+
+  return out;
+}
+
+const TOKENIZERS: Record<Language, (src: string) => Token[]> = {
+  shell: tokenizeShell,
+  css: tokenizeCss,
+  html: tokenizeHtml,
+  markdown: tokenizeMarkdown,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Render                                                             */
+/* ------------------------------------------------------------------ */
+
+export function highlight(code: string, language: Language): ReactNode {
+  return TOKENIZERS[language](code).map((token, i) =>
+    token.k ? (
+      <span key={i} className={KIND_CLASS[token.k]}>
+        {token.t}
+      </span>
+    ) : (
+      <Fragment key={i}>{token.t}</Fragment>
+    )
+  );
+}
+
+/** Picks a language from the snippet itself, so callers don't have to label every field. */
+export function detectLanguage(code: string): Language {
+  const trimmed = code.trim();
+  if (trimmed.startsWith("<")) return "html";
+  if (trimmed.startsWith("@") || trimmed.startsWith("--")) return "css";
+  return "shell";
+}

--- a/demo/src/utils/theme.ts
+++ b/demo/src/utils/theme.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "system" | "light" | "dark";
+export type ResolvedTheme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+function readStoredTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === "light" || stored === "dark" ? stored : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function resolveTheme(theme: Theme): ResolvedTheme {
+  if (theme !== "system") return theme;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+/* Mirrors the inline script in index.html, which paints the first frame before
+   React boots so there is no light-mode flash on a dark-mode reload. */
+function applyTheme(resolved: ResolvedTheme) {
+  const root = document.documentElement;
+  root.classList.toggle("dark", resolved === "dark");
+  root.style.colorScheme = resolved;
+  const favicon = document.querySelector<HTMLLinkElement>("link[rel='icon']");
+  if (favicon) favicon.href = resolved === "dark" ? "/favicon-dark.svg" : "/favicon-light.svg";
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(readStoredTheme);
+  const [resolved, setResolved] = useState<ResolvedTheme>(() => resolveTheme(readStoredTheme()));
+
+  useEffect(() => {
+    const sync = () => setResolved(resolveTheme(theme));
+    sync();
+    // Only matters while on "system", but the listener is cheap and this keeps
+    // the effect free of a second dependency path.
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, [theme]);
+
+  useEffect(() => {
+    applyTheme(resolved);
+  }, [resolved]);
+
+  const setTheme = useCallback((next: Theme) => {
+    try {
+      if (next === "system") localStorage.removeItem(STORAGE_KEY);
+      else localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* private mode — the choice just won't survive a reload */
+    }
+    setThemeState(next);
+  }, []);
+
+  return { theme, resolved, setTheme };
+}

--- a/demo/src/utils/theme.ts
+++ b/demo/src/utils/theme.ts
@@ -22,11 +22,14 @@ function resolveTheme(theme: Theme): ResolvedTheme {
 /* Mirrors the inline script in index.html, which paints the first frame before
    React boots so there is no light-mode flash on a dark-mode reload. */
 function applyTheme(resolved: ResolvedTheme) {
+  const dark = resolved === "dark";
   const root = document.documentElement;
-  root.classList.toggle("dark", resolved === "dark");
+  root.classList.toggle("dark", dark);
   root.style.colorScheme = resolved;
   const favicon = document.querySelector<HTMLLinkElement>("link[rel='icon']");
-  if (favicon) favicon.href = resolved === "dark" ? "/favicon-dark.svg" : "/favicon-light.svg";
+  if (favicon) favicon.href = dark ? "/favicon-dark.svg" : "/favicon-light.svg";
+  const themeColor = document.querySelector<HTMLMetaElement>("meta[name='theme-color']");
+  if (themeColor) themeColor.content = dark ? "#000000" : "#ffffff";
 }
 
 export function useTheme() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "printWidth": 100
   },
   "devDependencies": {
-    "@tailwindcss/cli": "4.1.13",
-    "tailwindcss": "4.1.13"
+    "@tailwindcss/cli": "^4.3.3",
+    "tailwindcss": "^4.3.3"
   }
 }


### PR DESCRIPTION
Three additions to the demo site. No changes to the plugin itself — `src/` is untouched.

## Theme toggle

A System / Light / Dark segmented control in the header, so light mode no longer means changing your OS setting.

- `dark:` now runs off a class variant (`@custom-variant dark (&:where(.dark, .dark *))`) instead of the media query, so a manual choice can override the system one.
- An inline script in `index.html` paints the stored theme before the first frame — a dark-mode reload never flashes white. It's kept in sync with `src/utils/theme.ts`, which is noted in both files.
- The favicon follows the resolved theme (it used to be driven by two `media`-scoped `<link>` tags, which a manual toggle can't reach).
- On "System" the page still tracks the OS live via a `matchMedia` listener.
- The active pill is a `smooth-shadow-ring-xs`.

Verified across all six transitions: system(OS=dark) → Light → reload → Dark → System → OS flipped to light. Class, `color-scheme`, `localStorage`, and favicon are correct at each step.

## Snippet colors

Every code snippet gets a hint of color, via a small tokenizer in `src/utils/highlight.tsx` rather than a highlighter dependency. Covers the four languages actually on the page: shell, css, html, and the two markdown files.

Three accents on a neutral base — violet for at-rules and tags, emerald for strings and values, sky for identifiers — with punctuation dropped back so each block still reads as one unit. The agent-skill markdown stays legible as prose.

## Color switches

Modeled on the gradient-border plugin demo, down to the swatch set, so the two pages read as one family. Pick **Shadow** or **Ring** as the target, tint it from the presets, and both preview boxes plus the generated class string update live. This is the feature worth showing off — the ring and shadow really do tint independently.

Two judgment calls, both easy to change:

- **Ring alpha is fixed at 30%.** At the default 5% a tinted hairline disappears; too much opacity turns it back into the hard border the plugin exists to avoid. The emitted class quotes the same number (`smooth-ring-violet-400/30`), so what you copy is what you see.
- **Colors reset to per-theme defaults when the theme flips** — a black shadow is invisible on black. Same behavior as the gradient-border configurator, but it does mean toggling the theme discards your picks.

The Ring target disables itself under "No ring", since `smooth-ring-*` has nothing to color there.

## Housekeeping

`app.tsx` was getting long with the playground inline, so it's split into `src/components/` (`code-field`, `copy-button`, `shadow-playground`, `theme-toggle`), matching the gradient-border demo's layout.

## Checks

`tsc -b`, `eslint .`, and `vite build` all pass. Screenshots were reviewed in both themes at each iteration.

One note for review: the sandbox this was built in blocks `cdn.floriankiem.com`, so Haas Recast and Commit Mono fell back to system faces in every screenshot. The `@font-face` rules and the `@theme` font tokens are unmodified — worth a glance at the preview deploy to confirm the type looks right.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhMV83MJ8rvNLs7CTY53Fz)_