### PR TITLE
feat!: drop !important and add unprefixed entrypoint

### DIFF
--- a/.claude/skills/smooth-shadow-ring/SKILL.md
+++ b/.claude/skills/smooth-shadow-ring/SKILL.md
@@ -54,6 +54,18 @@ raised dark surface, and too low an alpha makes the edge land on the surface's
 own colour and disappear. If a surface is light enough to sit near the ring
 anyway (`neutral-700` and up on a dark page), set `smooth-ring-*` explicitly.
 
+## Overriding
+
+The utilities carry no `!important` and follow the normal cascade, so a later
+utility, an inline `style`, or a JS animation on `box-shadow` overrides them
+normally. When one has to win against CSS that outranks it — a component
+library's own `box-shadow`, which usually ships unlayered — use Tailwind's
+important modifier on that element instead of a global override:
+
+```html
+<div class="smooth-shadow-ring-md!">…</div>
+```
+
 ## Example
 
 ```html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
 - Color the shadow with tokens like `shadow-red-500`
 - For elevated surfaces (dialogs, popovers, cards, menus) use `smooth-shadow-ring` or the size variants `smooth-shadow-ring-xs` up to `smooth-shadow-ring-2xl`, the shadow with a 1px hairline ring baked in; never add a `border`/`ring` to the same element
 - Color the ring independently from the shadow with `smooth-ring-{color}`, e.g. `smooth-ring-black/10`
+- The utilities carry no `!important` and follow the normal cascade. If one must win against CSS that outranks it (a component library's own `box-shadow`), use Tailwind's important modifier on that element — `smooth-shadow-md!` — rather than a global override
+- To replace Tailwind's own shadow scale instead of adding new class names, import `shadow-plugin/unprefixed` and use the native `shadow-{size}` utilities (this keeps `shadow-md/40` and `shadow-{color}` working; a `@theme { --shadow-md: var(--smooth-shadow-md); }` remap does not)
 
 ## Avoid double borders
 

--- a/README.md
+++ b/README.md
@@ -67,18 +67,30 @@ If your surface is light enough to sit near the ring anyway (`neutral-700` and u
 }
 ```
 
+### Overriding a smooth shadow
+
+The utilities are plain Tailwind utilities with no `!important`, so they follow the normal cascade — a later utility, an inline `style`, or a JS animation on `box-shadow` all override them the way you'd expect.
+
+If you need one to win against CSS that would otherwise beat it (a component library's own `box-shadow`, which usually ships unlayered), use Tailwind's important modifier rather than reaching for a global setting:
+
+```html
+<div class="smooth-shadow-md!" />
+```
+
+It works on every utility here, including variants and the ring: `smooth-shadow-ring-lg!`, `hover:smooth-shadow-lg!`, `smooth-ring-blue-500/40!`.
+
 ### Optional: Replace all your default shadows
 
+Import the unprefixed entrypoint and Tailwind's own `shadow-xs` … `shadow-2xl` render the smooth stacks — no new class names to learn:
+
 ```css
-@theme {
-  --shadow-xs: var(--smooth-shadow-xs);
-  --shadow-sm: var(--smooth-shadow-sm);
-  --shadow-md: var(--smooth-shadow-md);
-  --shadow-lg: var(--smooth-shadow-lg);
-  --shadow-xl: var(--smooth-shadow-xl);
-  --shadow-2xl: var(--smooth-shadow-2xl);
-}
+@import "tailwindcss";
+@import "shadow-plugin/unprefixed";
 ```
+
+Because it writes literal values into Tailwind's `--shadow-*` theme tokens, the full native feature set keeps working: the opacity modifier (`shadow-md/40`), `shadow-{color}`, and variants. The `smooth-shadow-ring-*` utilities have no native equivalent, so they come along under their own names. An existing scale migrates by deleting the `smooth-` prefix.
+
+> Don't use `@theme { --shadow-md: var(--smooth-shadow-md); }` for this. It renders, but Tailwind can't see inside the var to reach the individual layers, so `shadow-md/40` and `shadow-{color}` silently stop working.
 
 ## Available classes
 

--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -94,10 +94,16 @@ function App() {
           </div>
           <div>
             <h3 className="text-sm mb-1.5 text-neutral-400">
+              Override a shadow that loses to other CSS
+            </h3>
+            <CodeField code="<div className='smooth-shadow-md!' />" language="html" />
+          </div>
+          <div>
+            <h3 className="text-sm mb-1.5 text-neutral-400">
               Optional: Replace all your default shadows
             </h3>
             <CodeField
-              code={`@theme {\n  --shadow-xs: var(--smooth-shadow-xs);\n  --shadow-sm: var(--smooth-shadow-sm);\n  --shadow-md: var(--smooth-shadow-md);\n  --shadow-lg: var(--smooth-shadow-lg);\n  --shadow-xl: var(--smooth-shadow-xl);\n  --shadow-2xl: var(--smooth-shadow-2xl);\n}`}
+              code={`@import 'tailwindcss';\n@import 'shadow-plugin/unprefixed';`}
               language="css"
             />
           </div>

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.0.0-development",
   "description": "TailwindCSS plugin for adding nice looking shadows.",
   "scripts": {
-    "build": "mkdir -p dist && cat src/shadows.css src/shadow-ring.css > dist/shadow-plugin.css",
+    "build": "rm -rf dist && mkdir -p dist && cat src/shadows.css src/shadow-ring.css > dist/shadow-plugin.css && cat src/unprefixed.css src/shadow-ring.css > dist/shadow-plugin.unprefixed.css",
     "format": "prettier --write --ignore-unknown .",
     "demo": "open demo/index.html"
   },
-  "exports": "./dist/shadow-plugin.css",
+  "exports": {
+    ".": "./dist/shadow-plugin.css",
+    "./unprefixed": "./dist/shadow-plugin.unprefixed.css"
+  },
   "main": "./dist/shadow-plugin.css",
   "files": [
     "dist"

--- a/src/shadow-ring.css
+++ b/src/shadow-ring.css
@@ -79,13 +79,13 @@
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
     0 1.16px 1.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
-    0 0 0 1px var(--smooth-ring-color) !important;
+    0 0 0 1px var(--smooth-ring-color);
 }
 
 @utility smooth-shadow-ring-xs {
   --smooth-shadow-color: var(--tw-shadow-color, black);
   box-shadow: 0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
-    0 0 0 1px var(--smooth-ring-color) !important;
+    0 0 0 1px var(--smooth-ring-color);
 }
 
 @utility smooth-shadow-ring-sm {
@@ -96,7 +96,7 @@
     0 2.3px 5.8px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
     0 1.2px 3.1px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
     0 0.5px 1.3px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
-    0 0 0 1px var(--smooth-ring-color) !important;
+    0 0 0 1px var(--smooth-ring-color);
 }
 
 @utility smooth-shadow-ring-md {
@@ -106,7 +106,7 @@
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
     0 1.16px 1.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
-    0 0 0 1px var(--smooth-ring-color) !important;
+    0 0 0 1px var(--smooth-ring-color);
 }
 
 @utility smooth-shadow-ring-lg {
@@ -116,7 +116,7 @@
     0 6px 12px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 3px 6px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 1.5px 3px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
-    0 0 0 1px var(--smooth-ring-color) !important;
+    0 0 0 1px var(--smooth-ring-color);
 }
 
 @utility smooth-shadow-ring-xl {
@@ -126,7 +126,7 @@
     0 10px 20px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 5px 10px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 2px 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
-    0 0 0 1px var(--smooth-ring-color) !important;
+    0 0 0 1px var(--smooth-ring-color);
 }
 
 @utility smooth-shadow-ring-2xl {
@@ -136,7 +136,7 @@
     0 15px 30px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 7.5px 15px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 3px 6px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
-    0 0 0 1px var(--smooth-ring-color) !important;
+    0 0 0 1px var(--smooth-ring-color);
 }
 
 /*

--- a/src/shadows.css
+++ b/src/shadows.css
@@ -33,12 +33,12 @@
     0 9.4px 12.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
-    0 1.16px 1.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent) !important;
+    0 1.16px 1.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent);
 }
 
 @utility smooth-shadow-xs {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent) !important;
+  box-shadow: 0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent);
 }
 
 @utility smooth-shadow-sm {
@@ -48,7 +48,7 @@
     0 4px 10.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.3px 5.8px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
     0 1.2px 3.1px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
-    0 0.5px 1.3px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent) !important;
+    0 0.5px 1.3px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent);
 }
 
 @utility smooth-shadow-md {
@@ -57,7 +57,7 @@
     0 9.4px 12.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
-    0 1.16px 1.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent) !important;
+    0 1.16px 1.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent);
 }
 
 @utility smooth-shadow-lg {
@@ -66,7 +66,7 @@
     0 12px 24px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 6px 12px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 3px 6px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
-    0 1.5px 3px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent) !important;
+    0 1.5px 3px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent);
 }
 
 @utility smooth-shadow-xl {
@@ -75,7 +75,7 @@
     0 20px 40px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 10px 20px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 5px 10px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
-    0 2px 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent) !important;
+    0 2px 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent);
 }
 
 @utility smooth-shadow-2xl {
@@ -84,9 +84,9 @@
     0 30px 60px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
     0 15px 30px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 7.5px 15px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
-    0 3px 6px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent) !important;
+    0 3px 6px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent);
 }
 
 @utility smooth-shadow-none {
-  box-shadow: none !important;
+  box-shadow: none;
 }

--- a/src/unprefixed.css
+++ b/src/unprefixed.css
@@ -1,0 +1,39 @@
+/**
+ * TailwindCSS smooth shadow effect plugin — unprefixed entrypoint.
+ *
+ * Instead of adding `smooth-shadow-*` classes, this maps the smooth stacks
+ * onto Tailwind's own shadow scale, so the native `shadow-{size}` utilities
+ * render them. Because the values are literal layer lists (not var()
+ * references), Tailwind's build-time shadow machinery fully applies: the
+ * opacity modifier (`shadow-md/40`), `shadow-{color}`, and variants all work
+ * exactly like stock Tailwind.
+ *
+ * Note this is why the older `--shadow-md: var(--smooth-shadow-md)` recipe
+ * falls short: Tailwind cannot see inside the var to reach the individual
+ * layers, so `shadow-md/40` and `shadow-{color}` silently do nothing.
+ *
+ * `smooth-shadow-ring-*` has no native equivalent, so the ring utilities keep
+ * their names and are included here.
+ *
+ * @author Florian Kiem <https://github.com/flornkm>
+ * @license MIT
+ */
+
+@theme {
+  --shadow-xs: 0 0 4px 0 rgba(0, 0, 0, 0.04);
+  --shadow-sm: 0 18px 47px 0 rgba(0, 0, 0, 0.03), 0 7.5px 19px 0 rgba(0, 0, 0, 0.02),
+    0 4px 10.5px 0 rgba(0, 0, 0, 0.02), 0 2.3px 5.8px 0 rgba(0, 0, 0, 0.01),
+    0 1.2px 3.1px 0 rgba(0, 0, 0, 0.01), 0 0.5px 1.3px 0 rgba(0, 0, 0, 0.01);
+  --shadow-md: 0 17.54px 23.39px 0 rgba(0, 0, 0, 0.04), 0 9.4px 12.5px 0 rgba(0, 0, 0, 0.03),
+    0 5.25px 7px 0 rgba(0, 0, 0, 0.02), 0 2.79px 3.72px -2px rgba(0, 0, 0, 0.01),
+    0 1.16px 1.5px 0 rgba(0, 0, 0, 0.01);
+  --shadow-lg: 0 25px 50px 0 rgba(0, 0, 0, 0.05), 0 12px 24px 0 rgba(0, 0, 0, 0.04),
+    0 6px 12px 0 rgba(0, 0, 0, 0.03), 0 3px 6px 0 rgba(0, 0, 0, 0.02),
+    0 1.5px 3px 0 rgba(0, 0, 0, 0.02);
+  --shadow-xl: 0 40px 80px 0 rgba(0, 0, 0, 0.06), 0 20px 40px 0 rgba(0, 0, 0, 0.05),
+    0 10px 20px 0 rgba(0, 0, 0, 0.04), 0 5px 10px 0 rgba(0, 0, 0, 0.03),
+    0 2px 4px 0 rgba(0, 0, 0, 0.02);
+  --shadow-2xl: 0 60px 120px 0 rgba(0, 0, 0, 0.07), 0 30px 60px 0 rgba(0, 0, 0, 0.06),
+    0 15px 30px 0 rgba(0, 0, 0, 0.05), 0 7.5px 15px 0 rgba(0, 0, 0, 0.04),
+    0 3px 6px 0 rgba(0, 0, 0, 0.03);
+}


### PR DESCRIPTION
Releases **2.0.0**.

## 1. Drop `!important`

The utilities no longer emit `!important`. Tested in a browser: the original justification — beating Tailwind's own `shadow-*` on the same element — is handled by cascade order alone, since Tailwind v4 sorts `.smooth-shadow-md` after `.shadow-md` in the utilities layer. What the marker actually did was block every legitimate override, including inline `style` and JS animations on `box-shadow`.

Elements that must win against CSS outranking them use Tailwind's important modifier instead:

```html
<div class="smooth-shadow-md!" />
```

Verified this works on every utility here and stamps `!important` onto all declarations (including the `--smooth-shadow-color` var and the `@supports` color-mix branch): `smooth-shadow-ring-lg!`, `hover:smooth-shadow-lg!`, `md:smooth-shadow-xl!`, `smooth-ring-blue-500/40!`, `smooth-shadow-none!`. The legacy leading form (`!smooth-shadow-md`) also compiles.

This is per-element, visible in the markup, and reachable by consumers — strictly more flexible than the global marker.

## 2. `shadow-plugin/unprefixed`

```css
@import "tailwindcss";
@import "shadow-plugin/unprefixed";
```

Writes the smooth stacks as **literal values** into Tailwind's own `--shadow-*` theme tokens, so native `shadow-xs` … `shadow-2xl` render them with the full native feature set: `shadow-md/40`, `shadow-{color}`, variants. `smooth-shadow-ring-*` has no native equivalent and comes along under its own name.

This replaces the previously documented `@theme { --shadow-md: var(--smooth-shadow-md); }` recipe. That recipe renders, but I confirmed by compiling it that `shadow-md/40` emits `--tw-shadow-alpha: 40%` next to an opaque `var()` and silently no-ops, and `shadow-blue-500` sets `--tw-shadow-color` with nothing to substitute into. The README now warns against it.

## 3. Docs

README, `AGENTS.md`, the agent skill, and the demo's usage section all document the `!` modifier and the unprefixed entry. The skill and Bugbot rule are raw-imported by the demo, so the site picks the changes up on deploy.

## 4. Build hygiene

`build` now `rm -rf dist` first. Caught during this work: a stale `no-important.css` from an earlier iteration survived a rebuild, and since `files: ["dist"]` publishes the whole directory it would have shipped.

## Verification

Fully isolated project (fresh `npm pack` → install, Tailwind v4.3.3 CLI):

- Default entry: all 14 size utilities + ring + color composition emit; **zero** plugin `!important` in output (the only ones present come from the intentional `!` test classes).
- Unprefixed: `.shadow-md` carries the smooth 5-layer stack via `--tw-shadow`; `shadow-md/40` multiplies every layer to 40%; `shadow-blue-500` tints natively.
- `npm pack` ships exactly `LICENSE`, `README.md`, `package.json`, `dist/shadow-plugin.css`, `dist/shadow-plugin.unprefixed.css`.

Demo regression check: builds clean, no console errors, computed shadows unchanged on every elevated surface, and light + dark screenshots are identical to the live 1.2.7 site. Confirmed beforehand that nothing in the demo pairs a smooth utility with competing CSS — the playground tints via inline custom properties, not `box-shadow`, and `.size-slider-thumb` carries no smooth class. Demo CSS is 0.55 kB smaller.

## Breaking change

A smooth shadow that previously won against unlayered CSS (component-library styles) may now lose to it. Fix is per element: `class="smooth-shadow-md!"`.

## 5. Ring width follows the project's Tailwind ring width

From user feedback: a project on `--default-ring-width: 0.5px` got a hardcoded 1px hairline with no way to fix it short of overriding every utility.

```css
@theme {
  --default-ring-width: 0.5px; /* the hairline follows automatically */
}
```

Implementation is `theme(--default-ring-width, 1px)` inlined at build time onto a `--smooth-ring-width` custom property. Two findings made this the only workable form — both verified by compiling:

- Build-time resolution is **required**. Tailwind resolves the `--default-*` namespace at build time and never emits it as a runtime custom property (it is absent from compiled output), so a plain `var(--default-ring-width, 1px)` would always take the 1px fallback and silently do nothing.
- The fallback argument is **load-bearing**. `theme(--default-ring-width)` without one aborts the build with `Could not resolve value for theme function` for every project that has not set the variable — which is most of them.

Landing it on a custom property (rather than inlining into each utility) keeps it overridable at any scope, including per element via `[--smooth-ring-width:2px]`.

Verified in the isolated project: unset → `:root { --smooth-ring-width: 1px }` and a rendered 1px ring, identical to today; `--default-ring-width: 0.5px` → 0.5px var and a rendered 0.5px ring; scoped `--smooth-ring-width: 3px` → rendered 3px. Demo unchanged at 1px with no console errors.
