### PR TITLE
feat: add ambient layers to shadow scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The ring and the shadow are colored independently. `shadow-{color}` tints the sh
 <div class="smooth-shadow-ring-md smooth-ring-blue-500/40 shadow-blue-500" />
 ```
 
+Every size includes a scaled zero-offset ambient layer. This keeps the surface separated above and on both sides while the directional layers remain stronger below.
+
 The ring defaults to `rgba(0, 0, 0, 0.05)` and flips to `rgba(255, 255, 255, 0.18)` in dark mode. That happens automatically under a `.dark` class, `data-theme="dark"`, or — for OS-preference dark modes — whenever the page declares `color-scheme: light dark`.
 
 The flip deliberately never keys off `prefers-color-scheme` alone: that media query reports the visitor's OS setting, not whether your site has a dark theme, so a light-only site keeps its light ring for every visitor instead of serving dark-OS users an invisible white hairline. If your dark mode is driven purely by a `prefers-color-scheme` media query, declare it (good practice anyway — it also fixes scrollbars and form controls) and the ring follows automatically:
@@ -57,7 +59,7 @@ The flip deliberately never keys off `prefers-color-scheme` alone: that media qu
 }
 ```
 
-The dark alpha is deliberately much higher than the light one. The ring is an outer layer, so it paints on the page *behind* the surface and takes its rendered colour from the page background rather than from the surface it outlines. In light mode that is forgiving, because a black hairline darkens away from any near-white surface. In dark mode a white hairline lightens *toward* a raised surface, so too low an alpha lands the ring on the surface's own colour and the edge vanishes.
+The dark alpha is deliberately much higher than the light one. The ring is an outer layer, so it paints on the page _behind_ the surface and takes its rendered colour from the page background rather than from the surface it outlines. In light mode that is forgiving, because a black hairline darkens away from any near-white surface. In dark mode a white hairline lightens _toward_ a raised surface, so too low an alpha lands the ring on the surface's own colour and the edge vanishes.
 
 If your surface is light enough to sit near the ring anyway (`neutral-700` and up on a dark page), set it explicitly:
 

--- a/src/shadow-ring.css
+++ b/src/shadow-ring.css
@@ -79,18 +79,20 @@
 }
 
 .light,
-[data-theme='light'] {
+[data-theme="light"] {
   --smooth-ring-color: rgba(0, 0, 0, 0.05);
 }
 
 .dark,
-[data-theme='dark'] {
+[data-theme="dark"] {
   --smooth-ring-color: rgba(255, 255, 255, 0.18);
 }
 
 @utility smooth-shadow-ring {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+  box-shadow:
+    0 0 8px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+    0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 9.4px 12.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
@@ -100,13 +102,17 @@
 
 @utility smooth-shadow-ring-xs {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+  box-shadow:
+    0 0 2px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
+    0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 0 0 var(--smooth-ring-width, 1px) var(--smooth-ring-color);
 }
 
 @utility smooth-shadow-ring-sm {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 18px 47px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+  box-shadow:
+    0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
+    0 18px 47px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 7.5px 19px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 4px 10.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.3px 5.8px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
@@ -117,7 +123,9 @@
 
 @utility smooth-shadow-ring-md {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+  box-shadow:
+    0 0 8px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+    0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 9.4px 12.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
@@ -127,7 +135,9 @@
 
 @utility smooth-shadow-ring-lg {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 25px 50px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
+  box-shadow:
+    0 0 10px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+    0 25px 50px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 12px 24px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 6px 12px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 3px 6px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
@@ -137,7 +147,9 @@
 
 @utility smooth-shadow-ring-xl {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 40px 80px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
+  box-shadow:
+    0 0 12px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+    0 40px 80px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
     0 20px 40px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 10px 20px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 5px 10px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
@@ -147,7 +159,9 @@
 
 @utility smooth-shadow-ring-2xl {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 60px 120px 0 color-mix(in srgb, var(--smooth-shadow-color) 7%, transparent),
+  box-shadow:
+    0 0 16px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+    0 60px 120px 0 color-mix(in srgb, var(--smooth-shadow-color) 7%, transparent),
     0 30px 60px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
     0 15px 30px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 7.5px 15px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
@@ -170,10 +184,10 @@
    * the `/<opacity>` modifier layers in on a second line that overrides it
    * when present.
    */
-  --smooth-ring-color: --value(--color- *);
+  --smooth-ring-color: --value(--color-*);
   --smooth-ring-color: color-mix(
     in srgb,
-    --value(--color- *) calc(--modifier(number) * 1%),
+    --value(--color-*) calc(--modifier(number) * 1%),
     transparent
   );
 }

--- a/src/shadows.css
+++ b/src/shadows.css
@@ -9,27 +9,35 @@
  */
 
 @theme {
-  --smooth-shadow-xs: 0 0 4px 0 rgba(0, 0, 0, 0.04);
-  --smooth-shadow-sm: 0 18px 47px 0 rgba(0, 0, 0, 0.03), 0 7.5px 19px 0 rgba(0, 0, 0, 0.02),
-    0 4px 10.5px 0 rgba(0, 0, 0, 0.02), 0 2.3px 5.8px 0 rgba(0, 0, 0, 0.01),
-    0 1.2px 3.1px 0 rgba(0, 0, 0, 0.01), 0 0.5px 1.3px 0 rgba(0, 0, 0, 0.01);
-  --smooth-shadow-md: 0 17.54px 23.39px 0 rgba(0, 0, 0, 0.04), 0 9.4px 12.5px 0 rgba(0, 0, 0, 0.03),
-    0 5.25px 7px 0 rgba(0, 0, 0, 0.02), 0 2.79px 3.72px -2px rgba(0, 0, 0, 0.01),
-    0 1.16px 1.5px 0 rgba(0, 0, 0, 0.01);
-  --smooth-shadow-lg: 0 25px 50px 0 rgba(0, 0, 0, 0.05), 0 12px 24px 0 rgba(0, 0, 0, 0.04),
-    0 6px 12px 0 rgba(0, 0, 0, 0.03), 0 3px 6px 0 rgba(0, 0, 0, 0.02),
-    0 1.5px 3px 0 rgba(0, 0, 0, 0.02);
-  --smooth-shadow-xl: 0 40px 80px 0 rgba(0, 0, 0, 0.06), 0 20px 40px 0 rgba(0, 0, 0, 0.05),
-    0 10px 20px 0 rgba(0, 0, 0, 0.04), 0 5px 10px 0 rgba(0, 0, 0, 0.03),
-    0 2px 4px 0 rgba(0, 0, 0, 0.02);
-  --smooth-shadow-2xl: 0 60px 120px 0 rgba(0, 0, 0, 0.07), 0 30px 60px 0 rgba(0, 0, 0, 0.06),
-    0 15px 30px 0 rgba(0, 0, 0, 0.05), 0 7.5px 15px 0 rgba(0, 0, 0, 0.04),
-    0 3px 6px 0 rgba(0, 0, 0, 0.03);
+  --smooth-shadow-xs: 0 0 2px 0 rgba(0, 0, 0, 0.02), 0 0 4px 0 rgba(0, 0, 0, 0.04);
+  --smooth-shadow-sm:
+    0 0 4px 0 rgba(0, 0, 0, 0.02), 0 18px 47px 0 rgba(0, 0, 0, 0.03),
+    0 7.5px 19px 0 rgba(0, 0, 0, 0.02), 0 4px 10.5px 0 rgba(0, 0, 0, 0.02),
+    0 2.3px 5.8px 0 rgba(0, 0, 0, 0.01), 0 1.2px 3.1px 0 rgba(0, 0, 0, 0.01),
+    0 0.5px 1.3px 0 rgba(0, 0, 0, 0.01);
+  --smooth-shadow-md:
+    0 0 8px 0 rgba(0, 0, 0, 0.03), 0 17.54px 23.39px 0 rgba(0, 0, 0, 0.04),
+    0 9.4px 12.5px 0 rgba(0, 0, 0, 0.03), 0 5.25px 7px 0 rgba(0, 0, 0, 0.02),
+    0 2.79px 3.72px -2px rgba(0, 0, 0, 0.01), 0 1.16px 1.5px 0 rgba(0, 0, 0, 0.01);
+  --smooth-shadow-lg:
+    0 0 10px 0 rgba(0, 0, 0, 0.03), 0 25px 50px 0 rgba(0, 0, 0, 0.05),
+    0 12px 24px 0 rgba(0, 0, 0, 0.04), 0 6px 12px 0 rgba(0, 0, 0, 0.03),
+    0 3px 6px 0 rgba(0, 0, 0, 0.02), 0 1.5px 3px 0 rgba(0, 0, 0, 0.02);
+  --smooth-shadow-xl:
+    0 0 12px 0 rgba(0, 0, 0, 0.04), 0 40px 80px 0 rgba(0, 0, 0, 0.06),
+    0 20px 40px 0 rgba(0, 0, 0, 0.05), 0 10px 20px 0 rgba(0, 0, 0, 0.04),
+    0 5px 10px 0 rgba(0, 0, 0, 0.03), 0 2px 4px 0 rgba(0, 0, 0, 0.02);
+  --smooth-shadow-2xl:
+    0 0 16px 0 rgba(0, 0, 0, 0.04), 0 60px 120px 0 rgba(0, 0, 0, 0.07),
+    0 30px 60px 0 rgba(0, 0, 0, 0.06), 0 15px 30px 0 rgba(0, 0, 0, 0.05),
+    0 7.5px 15px 0 rgba(0, 0, 0, 0.04), 0 3px 6px 0 rgba(0, 0, 0, 0.03);
 }
 
 @utility smooth-shadow {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+  box-shadow:
+    0 0 8px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+    0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 9.4px 12.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
@@ -38,12 +46,16 @@
 
 @utility smooth-shadow-xs {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent);
+  box-shadow:
+    0 0 2px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
+    0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent);
 }
 
 @utility smooth-shadow-sm {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 18px 47px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+  box-shadow:
+    0 0 4px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
+    0 18px 47px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 7.5px 19px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 4px 10.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.3px 5.8px 0 color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
@@ -53,7 +65,9 @@
 
 @utility smooth-shadow-md {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+  box-shadow:
+    0 0 8px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+    0 17.54px 23.39px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 9.4px 12.5px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 5.25px 7px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
     0 2.79px 3.72px -2px color-mix(in srgb, var(--smooth-shadow-color) 1%, transparent),
@@ -62,7 +76,9 @@
 
 @utility smooth-shadow-lg {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 25px 50px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
+  box-shadow:
+    0 0 10px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+    0 25px 50px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 12px 24px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 6px 12px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
     0 3px 6px 0 color-mix(in srgb, var(--smooth-shadow-color) 2%, transparent),
@@ -71,7 +87,9 @@
 
 @utility smooth-shadow-xl {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 40px 80px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
+  box-shadow:
+    0 0 12px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+    0 40px 80px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
     0 20px 40px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 10px 20px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
     0 5px 10px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
@@ -80,7 +98,9 @@
 
 @utility smooth-shadow-2xl {
   --smooth-shadow-color: var(--tw-shadow-color, black);
-  box-shadow: 0 60px 120px 0 color-mix(in srgb, var(--smooth-shadow-color) 7%, transparent),
+  box-shadow:
+    0 0 16px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+    0 60px 120px 0 color-mix(in srgb, var(--smooth-shadow-color) 7%, transparent),
     0 30px 60px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
     0 15px 30px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
     0 7.5px 15px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),

--- a/src/unprefixed.css
+++ b/src/unprefixed.css
@@ -20,20 +20,26 @@
  */
 
 @theme {
-  --shadow-xs: 0 0 4px 0 rgba(0, 0, 0, 0.04);
-  --shadow-sm: 0 18px 47px 0 rgba(0, 0, 0, 0.03), 0 7.5px 19px 0 rgba(0, 0, 0, 0.02),
-    0 4px 10.5px 0 rgba(0, 0, 0, 0.02), 0 2.3px 5.8px 0 rgba(0, 0, 0, 0.01),
-    0 1.2px 3.1px 0 rgba(0, 0, 0, 0.01), 0 0.5px 1.3px 0 rgba(0, 0, 0, 0.01);
-  --shadow-md: 0 17.54px 23.39px 0 rgba(0, 0, 0, 0.04), 0 9.4px 12.5px 0 rgba(0, 0, 0, 0.03),
-    0 5.25px 7px 0 rgba(0, 0, 0, 0.02), 0 2.79px 3.72px -2px rgba(0, 0, 0, 0.01),
-    0 1.16px 1.5px 0 rgba(0, 0, 0, 0.01);
-  --shadow-lg: 0 25px 50px 0 rgba(0, 0, 0, 0.05), 0 12px 24px 0 rgba(0, 0, 0, 0.04),
-    0 6px 12px 0 rgba(0, 0, 0, 0.03), 0 3px 6px 0 rgba(0, 0, 0, 0.02),
-    0 1.5px 3px 0 rgba(0, 0, 0, 0.02);
-  --shadow-xl: 0 40px 80px 0 rgba(0, 0, 0, 0.06), 0 20px 40px 0 rgba(0, 0, 0, 0.05),
-    0 10px 20px 0 rgba(0, 0, 0, 0.04), 0 5px 10px 0 rgba(0, 0, 0, 0.03),
-    0 2px 4px 0 rgba(0, 0, 0, 0.02);
-  --shadow-2xl: 0 60px 120px 0 rgba(0, 0, 0, 0.07), 0 30px 60px 0 rgba(0, 0, 0, 0.06),
-    0 15px 30px 0 rgba(0, 0, 0, 0.05), 0 7.5px 15px 0 rgba(0, 0, 0, 0.04),
-    0 3px 6px 0 rgba(0, 0, 0, 0.03);
+  --shadow-xs: 0 0 2px 0 rgba(0, 0, 0, 0.02), 0 0 4px 0 rgba(0, 0, 0, 0.04);
+  --shadow-sm:
+    0 0 4px 0 rgba(0, 0, 0, 0.02), 0 18px 47px 0 rgba(0, 0, 0, 0.03),
+    0 7.5px 19px 0 rgba(0, 0, 0, 0.02), 0 4px 10.5px 0 rgba(0, 0, 0, 0.02),
+    0 2.3px 5.8px 0 rgba(0, 0, 0, 0.01), 0 1.2px 3.1px 0 rgba(0, 0, 0, 0.01),
+    0 0.5px 1.3px 0 rgba(0, 0, 0, 0.01);
+  --shadow-md:
+    0 0 8px 0 rgba(0, 0, 0, 0.03), 0 17.54px 23.39px 0 rgba(0, 0, 0, 0.04),
+    0 9.4px 12.5px 0 rgba(0, 0, 0, 0.03), 0 5.25px 7px 0 rgba(0, 0, 0, 0.02),
+    0 2.79px 3.72px -2px rgba(0, 0, 0, 0.01), 0 1.16px 1.5px 0 rgba(0, 0, 0, 0.01);
+  --shadow-lg:
+    0 0 10px 0 rgba(0, 0, 0, 0.03), 0 25px 50px 0 rgba(0, 0, 0, 0.05),
+    0 12px 24px 0 rgba(0, 0, 0, 0.04), 0 6px 12px 0 rgba(0, 0, 0, 0.03),
+    0 3px 6px 0 rgba(0, 0, 0, 0.02), 0 1.5px 3px 0 rgba(0, 0, 0, 0.02);
+  --shadow-xl:
+    0 0 12px 0 rgba(0, 0, 0, 0.04), 0 40px 80px 0 rgba(0, 0, 0, 0.06),
+    0 20px 40px 0 rgba(0, 0, 0, 0.05), 0 10px 20px 0 rgba(0, 0, 0, 0.04),
+    0 5px 10px 0 rgba(0, 0, 0, 0.03), 0 2px 4px 0 rgba(0, 0, 0, 0.02);
+  --shadow-2xl:
+    0 0 16px 0 rgba(0, 0, 0, 0.04), 0 60px 120px 0 rgba(0, 0, 0, 0.07),
+    0 30px 60px 0 rgba(0, 0, 0, 0.06), 0 15px 30px 0 rgba(0, 0, 0, 0.05),
+    0 7.5px 15px 0 rgba(0, 0, 0, 0.04), 0 3px 6px 0 rgba(0, 0, 0, 0.03);
 }


### PR DESCRIPTION
## Summary

- add a scaled zero-offset ambient layer to every shadow size
- apply the same scale to prefixed utilities, shadow-ring utilities, and the unprefixed theme
- document the ambient separation behavior

The directional layers remain unchanged. The new layer improves separation above and beside elevated surfaces while preserving the stronger shadow below.

## Ambient scale

| Size | Layer |
| --- | --- |
| xs | `0 0 2px / 2%` |
| sm | `0 0 4px / 2%` |
| md | `0 0 8px / 3%` |
| lg | `0 0 10px / 3%` |
| xl | `0 0 12px / 4%` |
| 2xl | `0 0 16px / 4%` |

## Verification

- formatted changed CSS and README files with Prettier
- ran `npm run build`
- verified generated prefixed and unprefixed CSS contain the XL ambient layer in theme, ringless, and ring utilities

Note: `npm ci` currently fails on `main` because `package-lock.json` contains Tailwind 4.1.13 while `package.json` requests 4.3.3, so validation installed dependencies without modifying the lockfile.