### PR TITLE
feat: add customizable elevation shadow scale

### DIFF
--- a/.claude/skills/smooth-shadow-ring/SKILL.md
+++ b/.claude/skills/smooth-shadow-ring/SKILL.md
@@ -3,7 +3,7 @@ name: smooth-shadow-ring
 description: Use when styling any elevated surface (card, dialog, popover, dropdown, menu, tooltip, sheet, toast) in a Tailwind project that has shadow-plugin installed. Prevents the double-border artifact caused by pairing a border/ring with a shadow, by routing elevation through the smooth-shadow-ring-* utilities.
 ---
 
-# Elevated surfaces: use smooth-shadow-ring, never border + shadow
+# Elevated surfaces: choose ring softness or distance elevation
 
 ## When this applies
 
@@ -20,9 +20,10 @@ soft one. It looks heavy, greyed, and cheap.
 ## The rule
 
 If you are about to write a `border-*` or `ring-*` class next to any `shadow-*`
-on an elevated surface, use `smooth-shadow-ring-{size}` instead. It bakes a 1px
-hairline ring into the final shadow layer, so the edge dissolves into the shadow
-as one continuous stroke.
+on an elevated surface, first choose the intended semantics. For softness and
+emphasis, use `smooth-shadow-ring-{size}`; it bakes a 1px hairline ring into the
+final shadow layer. For actual distance hierarchy, remove the border/ring and
+use `smooth-shadow-elevation-{0..5}`.
 
 - `border shadow-md` → `smooth-shadow-ring-md`
 - `ring-1 ring-neutral-200 shadow-lg` → `smooth-shadow-ring-lg`
@@ -31,6 +32,8 @@ as one continuous stroke.
   `smooth-shadow-ring-*`. The ring is already in there; a second edge doubles up.
 - If the surface should have no edge stroke at all, use plain
   `smooth-shadow-{size}` (no ring), not a border.
+- If the surface's level must read as physical distance, use
+  `smooth-shadow-elevation-{0..5}` without a separate border or ring.
 
 ## Coloring
 
@@ -73,6 +76,19 @@ important modifier on that element instead of a global override:
 ```html
 <div class="smooth-shadow-ring-md!">…</div>
 ```
+
+For distance semantics, use `smooth-shadow-elevation-0` through
+`smooth-shadow-elevation-5`. They keep a crisp contact shadow while moving the
+ambient layer farther out and reducing both layers' alpha. Keep the default
+`smooth-shadow-*` scale for softness/emphasis semantics.
+
+```html
+<div class="smooth-shadow-elevation-3 shadow-blue-500/50">…</div>
+```
+
+Override a complete level with `--smooth-shadow-elevation-{n}` at the project,
+component, or element scope. Custom recipes own their colors; Tailwind
+`shadow-{color}` continues to tint the built-in recipes.
 
 ## Example
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 
 - Use `smooth-shadow`, or the size variants `smooth-shadow-xs` up to `smooth-shadow-2xl`
 - Color the shadow with tokens like `shadow-red-500`
-- For elevated surfaces (dialogs, popovers, cards, menus) use `smooth-shadow-ring` or the size variants `smooth-shadow-ring-xs` up to `smooth-shadow-ring-2xl`, the shadow with a 1px hairline ring baked in; never add a `border`/`ring` to the same element
+- Use `smooth-shadow-elevation-0` through `smooth-shadow-elevation-5` when the level must communicate actual distance from the surface; do not add a separate `border`/`ring` to the same element
+- Customize an elevation recipe as one semantic token with `--smooth-shadow-elevation-{n}`; do not add per-layer adjustment variables
+- For a soft shadow with a hairline edge, use `smooth-shadow-ring` or the size variants `smooth-shadow-ring-xs` up to `smooth-shadow-ring-2xl`; never add a `border`/`ring` to the same element
 - Color the ring independently from the shadow with `smooth-ring-{color}`, e.g. `smooth-ring-black/10`
 - The hairline follows the project's `--default-ring-width` automatically (1px if unset); override `--smooth-ring-width` only when it must differ from the project ring width
 - The utilities carry no `!important` and follow the normal cascade. If one must win against CSS that outranks it (a component library's own `box-shadow`), use Tailwind's important modifier on that element — `smooth-shadow-md!` — rather than a global override
@@ -18,5 +20,5 @@
 ## Avoid double borders
 
 - A `border-*` (or `ring-*`) next to a `shadow-*` on the same element draws two stacked edges: a hard line, then the shadow starting just outside it. That double border reads heavy and greyed
-- Whenever you would pair a border/ring with a shadow on an elevated surface, use `smooth-shadow-ring-{size}` instead. It bakes a 1px hairline ring into the shadow's final layer so the edge dissolves into one continuous stroke
+- Whenever you would pair a border/ring with a softness shadow on an elevated surface, use `smooth-shadow-ring-{size}` instead. When the hierarchy needs distance semantics, remove the border/ring and use `smooth-shadow-elevation-{0..5}`
 - The reusable skill lives at `.claude/skills/smooth-shadow-ring/SKILL.md`; the Cursor Bugbot rule lives at `BUGBOT.md`

--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -8,11 +8,11 @@ tooltip, sheet, toast) that puts a `border-*` or `ring-*` utility and a
 artifact: the border paints a hard 1px stroke and the shadow's outer edge sits
 just beside it, so the edge reads as two stacked lines.
 
-**Fix:** replace the border/ring + shadow pair with a single
-`smooth-shadow-ring-{size}` utility from shadow-plugin, which bakes a 1px
-hairline ring into the shadow's final layer. Do not leave a `border` or `ring`
-on an element that already uses `smooth-shadow-ring-*`. The ring is already in
-there and a second edge doubles up.
+**Fix:** for softness/emphasis, replace the border/ring + shadow pair with a
+single `smooth-shadow-ring-{size}` utility from shadow-plugin, which bakes a
+1px hairline ring into the shadow's final layer. For actual distance hierarchy,
+remove the border/ring and use `smooth-shadow-elevation-{0..5}`. Do not leave a
+`border` or `ring` on either family.
 
 - Flag: `class="rounded-xl border border-neutral-200 shadow-md"`
 - Suggest: `class="rounded-xl smooth-shadow-ring-md"`
@@ -20,3 +20,7 @@ there and a second edge doubles up.
 Sizes: `smooth-shadow-ring-xs`, `-sm`, `-md` (or bare `smooth-shadow-ring`),
 `-lg`, `-xl`, `-2xl`. Tint the ring and shadow independently with
 `smooth-ring-{color}` and `shadow-{color}`.
+
+Elevation levels: `smooth-shadow-elevation-0` through
+`smooth-shadow-elevation-5`. They retain a crisp contact shadow while the
+ambient shadow separates farther and becomes lighter at higher levels.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,36 @@ The plugin supports Tailwind's shadow color utilities:
 <div class="smooth-shadow-md shadow-blue-500/50" />
 ```
 
+### Elevation shadows
+
+The default `smooth-shadow-*` scale is tuned for softness and emphasis. For
+actual distance semantics, use the optional `smooth-shadow-elevation-{0..5}`
+scale: every level keeps a crisp contact shadow while its ambient layer moves
+farther away and becomes lighter.
+
+```html
+<div class="smooth-shadow-elevation-3 shadow-blue-500/50" />
+```
+
+`smooth-shadow-elevation-0` removes the shadow. Override any complete level
+with its matching semantic token. Define it on `:root` for a project-wide
+scale, on a component scope, or on one element:
+
+```css
+.product-shell {
+  --smooth-shadow-elevation-3: 0 2px 3px rgb(0 0 0 / 6%),
+    0 14px 30px rgb(0 0 0 / 3%);
+}
+```
+
+This replaces the complete level rather than exposing each internal layer as a
+separate API. Custom recipes own their colors; `shadow-{color}` continues to
+tint the built-in recipes. The `unprefixed` entrypoint retains the explicit
+elevation class names.
+
 ### Shadow + ring
 
-For elevated surfaces (dialogs, popovers, cards, menus), use `smooth-shadow-ring-{size}`, the same stacked shadow with a 1px hairline ring baked in as the final layer, so the edge morphs into the shadow instead of sitting next to it as a separate `border`. Don't add a `border`/`ring` on top; the ring is already in there.
+For surfaces that need a soft shadow plus a hairline edge, use `smooth-shadow-ring-{size}`, the same stacked shadow with a 1px hairline ring baked in as the final layer, so the edge morphs into the shadow instead of sitting next to it as a separate `border`. Don't add a `border`/`ring` on top; the ring is already in there. Use the elevation scale above when the level must communicate distance instead.
 
 ```html
 <div class="smooth-shadow-ring-md" />
@@ -124,6 +151,7 @@ Because it writes literal values into Tailwind's `--shadow-*` theme tokens, the 
 | `smooth-shadow-2xl`                                | 2x large                                                               |
 | `smooth-shadow-none`                               | None                                                                   |
 | `smooth-shadow-ring-xs` … `smooth-shadow-ring-2xl` | Shadow + 1px hairline ring (`smooth-shadow-ring` = medium)             |
+| `smooth-shadow-elevation-0` … `-5`                 | Optional distance/elevation scale                                      |
 | `smooth-ring-{color}`                              | Ring color override, supports opacity (e.g. `smooth-ring-blue-500/40`) |
 
 The ring reads two custom properties you can set at any scope: `--smooth-ring-color` and `--smooth-ring-width`.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0-development",
   "description": "TailwindCSS plugin for adding nice looking shadows.",
   "scripts": {
-    "build": "rm -rf dist && mkdir -p dist && cat src/shadows.css src/shadow-ring.css > dist/shadow-plugin.css && cat src/unprefixed.css src/shadow-ring.css > dist/shadow-plugin.unprefixed.css",
+    "build": "rm -rf dist && mkdir -p dist && cat src/shadows.css src/shadow-ring.css src/elevation.css > dist/shadow-plugin.css && cat src/unprefixed.css src/shadow-ring.css src/elevation.css > dist/shadow-plugin.unprefixed.css",
+    "pretest": "npm run build",
+    "test": "node --test",
     "format": "prettier --write --ignore-unknown .",
     "demo": "open demo/index.html"
   },

--- a/src/elevation.css
+++ b/src/elevation.css
@@ -1,0 +1,60 @@
+/**
+ * Optional elevation-flavored shadow scale.
+ *
+ * Unlike smooth-shadow-* (which expresses softness), these levels express
+ * distance from the surface: a crisp contact layer stays near the edge while
+ * the independent ambient layer moves farther out and becomes lighter.
+ * Override a complete level with `--smooth-shadow-elevation-{n}` at any scope.
+ *
+ * @author Florian Kiem <https://github.com/flornkm>
+ * @license MIT
+ */
+
+@utility smooth-shadow-elevation-0 {
+  box-shadow: var(--smooth-shadow-elevation-0, none);
+}
+
+@utility smooth-shadow-elevation-1 {
+  --smooth-shadow-color: var(--tw-shadow-color, black);
+  box-shadow: var(
+    --smooth-shadow-elevation-1,
+    0 1px 2px 0 color-mix(in srgb, var(--smooth-shadow-color) 7%, transparent),
+    0 1px 8px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent)
+  );
+}
+
+@utility smooth-shadow-elevation-2 {
+  --smooth-shadow-color: var(--tw-shadow-color, black);
+  box-shadow: var(
+    --smooth-shadow-elevation-2,
+    0 1px 2px 0 color-mix(in srgb, var(--smooth-shadow-color) 6%, transparent),
+    0 4px 12px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent)
+  );
+}
+
+@utility smooth-shadow-elevation-3 {
+  --smooth-shadow-color: var(--tw-shadow-color, black);
+  box-shadow: var(
+    --smooth-shadow-elevation-3,
+    0 1px 2px 0 color-mix(in srgb, var(--smooth-shadow-color) 5%, transparent),
+    0 9px 18px 0 color-mix(in srgb, var(--smooth-shadow-color) 3.5%, transparent)
+  );
+}
+
+@utility smooth-shadow-elevation-4 {
+  --smooth-shadow-color: var(--tw-shadow-color, black);
+  box-shadow: var(
+    --smooth-shadow-elevation-4,
+    0 1px 2px 0 color-mix(in srgb, var(--smooth-shadow-color) 4%, transparent),
+    0 18px 28px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent)
+  );
+}
+
+@utility smooth-shadow-elevation-5 {
+  --smooth-shadow-color: var(--tw-shadow-color, black);
+  box-shadow: var(
+    --smooth-shadow-elevation-5,
+    0 1px 2px 0 color-mix(in srgb, var(--smooth-shadow-color) 3%, transparent),
+    0 32px 40px 0 color-mix(in srgb, var(--smooth-shadow-color) 2.5%, transparent)
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
  *
  * - shadows.css     — stacked `smooth-shadow-*` shadows (ringless)
  * - shadow-ring.css — `smooth-shadow-ring-*` (stacked shadow + 1px hairline ring)
+ * - elevation.css   — `smooth-shadow-elevation-{0..5}` distance scale
  *
  * @author Florian Kiem <https://github.com/flornkm>
  * @license MIT
@@ -10,3 +11,4 @@
 
 @import "./shadows.css";
 @import "./shadow-ring.css";
+@import "./elevation.css";

--- a/src/unprefixed.css
+++ b/src/unprefixed.css
@@ -12,8 +12,8 @@
  * falls short: Tailwind cannot see inside the var to reach the individual
  * layers, so `shadow-md/40` and `shadow-{color}` silently do nothing.
  *
- * `smooth-shadow-ring-*` has no native equivalent, so the ring utilities keep
- * their names and are included here.
+ * `smooth-shadow-ring-*` and `smooth-shadow-elevation-*` have no native
+ * equivalents, so those utilities keep their names and are included here.
  *
  * @author Florian Kiem <https://github.com/flornkm>
  * @license MIT

--- a/test/browser.test.mjs
+++ b/test/browser.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repo = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const chromeCandidates = [
+  process.env.CHROME_BIN,
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium",
+].filter(Boolean);
+
+async function firstExecutable(paths) {
+  for (const path of paths) {
+    try {
+      await execFileAsync(path, ["--version"]);
+      return path;
+    } catch {
+      // Keep looking for a browser supplied by the host or CI.
+    }
+  }
+  return null;
+}
+
+const chrome = await firstExecutable(chromeCandidates);
+
+test(
+  "browser resolves built-in colors and scoped complete-level overrides",
+  { skip: chrome ? false : "Chromium is not available" },
+  async () => {
+    const directory = await mkdtemp(join(repo, ".shadow-plugin-browser-"));
+    const input = join(directory, "input.css");
+    const output = join(directory, "output.css");
+    const html = join(directory, "index.html");
+
+    try {
+      await writeFile(
+        input,
+        `@import "tailwindcss";\n@import "${repo}/src/index.css";\n@source inline("smooth-shadow-elevation-1 smooth-shadow-elevation-3 smooth-shadow-elevation-5 shadow-blue-500/50");\n`,
+      );
+      await execFileAsync(
+        "npx",
+        ["--no-install", "@tailwindcss/cli", "--cwd", repo, "-i", input, "-o", output],
+        { cwd: repo },
+      );
+      await writeFile(
+        html,
+        `<!doctype html><link rel="stylesheet" href="file://${output}">
+<div id="low" class="smooth-shadow-elevation-1 shadow-blue-500/50"></div>
+<div id="high" class="smooth-shadow-elevation-5 shadow-blue-500/50"></div>
+<div style="--smooth-shadow-elevation-3: 0 2px 3px rgb(255 0 0 / 40%), 0 14px 30px rgb(255 0 0 / 20%)">
+  <div id="custom" class="smooth-shadow-elevation-3"></div>
+</div>
+<script>
+  const style = (id) => getComputedStyle(document.querySelector(id)).boxShadow;
+  document.body.dataset.low = style('#low');
+  document.body.dataset.high = style('#high');
+  document.body.dataset.custom = style('#custom');
+</script>`,
+      );
+
+      const { stdout } = await execFileAsync(
+        chrome,
+        ["--headless", "--no-sandbox", "--disable-gpu", "--dump-dom", `file://${html}`],
+        { maxBuffer: 1024 * 1024 * 4 },
+      );
+      const body = stdout.match(/<body[^>]+>/)?.[0] ?? "";
+      const attribute = (name) => body.match(new RegExp(`data-${name}="([^"]*)"`))?.[1] ?? "";
+      const low = attribute("low");
+      const high = attribute("high");
+      const custom = attribute("custom");
+
+      assert.doesNotMatch(low, /color\(srgb 0 0 0/);
+      assert.match(low, /1px 2px/);
+      assert.match(low, /1px 8px/);
+      assert.doesNotMatch(high, /color\(srgb 0 0 0/);
+      assert.match(high, /32px 40px/);
+      assert.match(custom, /rgba\(255, 0, 0, 0\.4\) 0px 2px 3px/);
+      assert.match(custom, /rgba\(255, 0, 0, 0\.2\) 0px 14px 30px/);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/elevation.test.mjs
+++ b/test/elevation.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repo = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const elevation = await readFile(new URL("../src/elevation.css", import.meta.url), "utf8");
+
+function utilityBody(name) {
+  const start = elevation.indexOf(`@utility ${name} {`);
+  assert.notEqual(start, -1, `${name} utility is missing`);
+  const end = elevation.indexOf("\n}", start);
+  return elevation.slice(start, end);
+}
+
+test("elevation levels separate ambient distance while reducing alpha", () => {
+  assert.match(
+    utilityBody("smooth-shadow-elevation-0"),
+    /box-shadow: var\(--smooth-shadow-elevation-0, none\)/,
+  );
+
+  let previousRatio = 0;
+  let previousContactAlpha = Infinity;
+  let previousAmbientAlpha = Infinity;
+
+  for (let level = 1; level <= 5; level += 1) {
+    const body = utilityBody(`smooth-shadow-elevation-${level}`);
+    assert.match(body, new RegExp(`box-shadow: var\\(\\s*--smooth-shadow-elevation-${level},`));
+    const layers = [
+      ...body.matchAll(
+        /0 ([\d.]+)px ([\d.]+)px 0 color-mix\(in srgb, var\(--smooth-shadow-color\) ([\d.]+)%/g,
+      ),
+    ].map(([, offset, blur, alpha]) => ({
+      offset: Number(offset),
+      blur: Number(blur),
+      alpha: Number(alpha),
+    }));
+
+    assert.equal(layers.length, 2, `elevation ${level} should have contact and ambient layers`);
+    assert.deepEqual(layers[0], { offset: 1, blur: 2, alpha: 8 - level });
+
+    const ambientRatio = layers[1].offset / layers[1].blur;
+    assert.ok(ambientRatio > previousRatio, `elevation ${level} should separate farther`);
+    assert.ok(layers[0].alpha < previousContactAlpha, `elevation ${level} contact alpha should decrease`);
+    assert.ok(layers[1].alpha < previousAmbientAlpha, `elevation ${level} ambient alpha should decrease`);
+
+    previousRatio = ambientRatio;
+    previousContactAlpha = layers[0].alpha;
+    previousAmbientAlpha = layers[1].alpha;
+  }
+});
+
+test("both published entrypoints contain the complete elevation scale", async () => {
+  for (const file of ["shadow-plugin.css", "shadow-plugin.unprefixed.css"]) {
+    const css = await readFile(new URL(`../dist/${file}`, import.meta.url), "utf8");
+    assert.doesNotMatch(css, /@import\s+["']\.\//);
+    for (let level = 0; level <= 5; level += 1) {
+      assert.match(css, new RegExp(`@utility smooth-shadow-elevation-${level}`));
+    }
+  }
+});
+
+test("Tailwind compiles the published elevation utilities", async () => {
+  const directory = await mkdtemp(join(repo, ".shadow-plugin-package-"));
+  const input = join(directory, "input.css");
+  const output = join(directory, "output.css");
+
+  try {
+    await writeFile(
+      input,
+      `@import "tailwindcss";\n@import "${repo}/dist/shadow-plugin.css";\n@source inline("smooth-shadow-elevation-0 smooth-shadow-elevation-3 smooth-shadow-elevation-5");\n`,
+    );
+    await execFileAsync(
+      "npx",
+      ["--no-install", "@tailwindcss/cli", "--cwd", repo, "-i", input, "-o", output],
+      { cwd: repo },
+    );
+    const css = await readFile(output, "utf8");
+    assert.match(css, /\.smooth-shadow-elevation-0\s*\{/);
+    assert.match(css, /\.smooth-shadow-elevation-3\s*\{/);
+    assert.match(css, /\.smooth-shadow-elevation-5\s*\{/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds an optional, customizable elevation scale for surfaces that need to communicate distance rather than shadow softness.

The existing `smooth-shadow-*` and `smooth-shadow-ring-*` families keep their current behavior. The new family is additive:

```html
<div class="smooth-shadow-elevation-3" />
<div class="smooth-shadow-elevation-3 shadow-blue-500/50" />
```

Available levels are `smooth-shadow-elevation-0` through `smooth-shadow-elevation-5`.

Closes #6.

## Problem

The existing size scale works well as a softness/emphasis scale, but increasing its size does not reliably communicate that a surface moved farther away:

- blur and offset largely grow together;
- the outer-layer alpha increases at larger sizes;
- there is no stable contact-shadow cue across the scale.

That makes a larger shadow read as heavier or softer, rather than necessarily higher. Changing the existing scale would also alter current visuals for every consumer, so this PR leaves it untouched and adds an opt-in distance-oriented family.

## Approach

Each non-zero elevation level contains two independently tuned layers:

1. A crisp `0 1px 2px` contact shadow that remains attached to the surface.
2. A broader ambient shadow whose offset separates progressively from its blur radius.

Across levels 1 through 5:

| Level | Contact alpha | Ambient shadow | Ambient alpha | Offset / blur |
| --- | ---: | --- | ---: | ---: |
| 1 | 7% | `0 1px 8px` | 5% | 0.125 |
| 2 | 6% | `0 4px 12px` | 4% | 0.333 |
| 3 | 5% | `0 9px 18px` | 3.5% | 0.500 |
| 4 | 4% | `0 18px 28px` | 3% | 0.643 |
| 5 | 3% | `0 32px 40px` | 2.5% | 0.800 |

This gives the scale three distance cues: a persistent contact edge, increasing separation, and decreasing alpha.

Level 0 resolves to `none`.

## Customization

Consumers can replace a complete semantic level rather than manipulating the implementation layer by layer:

```css
:root {
  --smooth-shadow-elevation-3: 0 2px 3px rgb(0 0 0 / 6%),
    0 14px 30px rgb(0 0 0 / 3%);
}
```

The token can be defined globally, on a component subtree, or on one element. This keeps application code coupled to the meaning of level 3 instead of its internal layer count.

Built-in recipes continue to compose with Tailwind's `shadow-{color}` utilities. A custom complete-level recipe owns both its geometry and colors.

## Package integration

- Includes the elevation family in the default package entrypoint.
- Includes the same explicit elevation classes in `shadow-plugin/unprefixed` without changing the native `shadow-*` remapping.
- Keeps both generated files self-contained; neither published entrypoint depends on a source-only relative import.
- Updates README usage, agent guidance, and Bugbot guidance to distinguish softness/ring treatment from distance semantics.

## Compatibility

- Existing classes and their generated values are unchanged.
- The new scale is opt-in.
- No global `!important` rules are introduced.
- Tailwind shadow colors still tint built-in elevation recipes.
- The package export map is unchanged.

## Verification

- `npm test` — 4 tests passed.
- `npm run build` — passed.
- `npm pack --dry-run` — passed; package contains both generated CSS entrypoints.
- `git diff --check` — passed.

The test suite verifies:

- all six elevation utilities are present in both published entrypoints;
- levels 1–5 retain the contact layer, increase ambient offset/blur separation, and reduce both alphas;
- Tailwind can compile the generated package entrypoint;
- Chromium resolves Tailwind color tinting for built-in levels;
- Chromium resolves a scoped `--smooth-shadow-elevation-3` override on a child element.

## Draft status

The API, package integration, and automated coverage are complete. This is opened as a draft so the level coefficients and visual ramp can be reviewed before marking it ready.
